### PR TITLE
fix: replace && exit guards with if/then/fi in delete-resource-group …

### DIFF
--- a/.github/workflows/delete-resource-group-aws.yml
+++ b/.github/workflows/delete-resource-group-aws.yml
@@ -57,8 +57,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          [[ -z "$RESOURCE_GROUP_NAME" ]] && { echo "::error::resource_group_name is required"; exit 1; }
-          [[ -z "$AWS_REGION"          ]] && { echo "::error::aws_region is required"; exit 1; }
+          if [[ -z "$RESOURCE_GROUP_NAME" ]]; then
+            echo "::error::resource_group_name is required"
+            exit 1
+          fi
+          if [[ -z "$AWS_REGION" ]]; then
+            echo "::error::aws_region is required"
+            exit 1
+          fi
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/delete-resource-group.yml
+++ b/.github/workflows/delete-resource-group.yml
@@ -48,7 +48,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          [[ -z "$RESOURCE_GROUP_NAME" ]] && { echo "::error::resource_group_name is required"; exit 1; }
+          if [[ -z "$RESOURCE_GROUP_NAME" ]]; then
+            echo "::error::resource_group_name is required"
+            exit 1
+          fi
           if [[ "$WAIT_FOR_COMPLETION" != "true" && "$WAIT_FOR_COMPLETION" != "false" ]]; then
             echo "::error::wait_for_completion must be either true or false"
             exit 1


### PR DESCRIPTION
…validate steps

The [[ -z "$VAR" ]] && { echo; exit 1; } pattern is ambiguous with set -euo pipefail: when the variable is non-empty, [[ ]] returns 1, && short-circuits, and the overall expression exits 1 — silently triggering set -e with no output. This caused the Validate inputs step in delete-resource-group-aws.yml to fail when called three levels deep (all → single → resource-group), blocking the delete-all workflow.

Replace with if/then/fi, which is unambiguous. Mirrored to the Azure delete-resource-group.yml for parity.

Fixes #46.