### PR TITLE
feat: preflight existence checks for template repos and container image

### DIFF
--- a/.github/workflows/provision-infrastructure-aws.yml
+++ b/.github/workflows/provision-infrastructure-aws.yml
@@ -255,11 +255,43 @@ jobs:
           EOF
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 2. Create infrastructure repository from template (idempotent)
+  # 2. Preflight existence checks — confirm the template repos (and any
+  #    pinned refs) exist and the container image is anonymously pullable
+  #    BEFORE anything is created. A mistyped value otherwise only surfaces
+  #    as a checkout failure mid-run — or worse, as a service waiting forever
+  #    for an image it can never pull. All findings are reported together in
+  #    the job summary. Gating create-infra-repo gates the entire downstream
+  #    graph, so nothing runs on bad inputs.
+  #
+  #    The repo checks use GH_PAT when configured (proving the accessibility
+  #    the app phase will need) and fall back to the workflow token, keeping
+  #    infra-only setups PAT-free as documented in setup-github.md.
+  # ────────────────────────────────────────────────────────────────────────────
+  preflight:
+    name: Preflight checks
+    needs: resolve-inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for helper script)
+        uses: actions/checkout@v6
+
+      - name: Verify template repos and container image
+        env:
+          GH_TOKEN:            ${{ secrets.GH_PAT || github.token }}
+          INFRA_TEMPLATE_REPO: ${{ needs.resolve-inputs.outputs.infra_template_repo }}
+          INFRA_TEMPLATE_REF:  ${{ needs.resolve-inputs.outputs.infra_template_ref }}
+          APP_TEMPLATE_REPO:   ${{ needs.resolve-inputs.outputs.app_template_repo }}
+          APP_TEMPLATE_REF:    ${{ needs.resolve-inputs.outputs.app_template_ref }}
+          CONTAINER_IMAGE_FULL: ${{ needs.resolve-inputs.outputs.container_image }}
+        run: |
+          scripts/preflight-inputs.sh
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # 3. Create infrastructure repository from template (idempotent)
   # ────────────────────────────────────────────────────────────────────────────
   create-infra-repo:
     name: Create infrastructure repo
-    needs: resolve-inputs
+    needs: [resolve-inputs, preflight]
     runs-on: ubuntu-latest
     outputs:
       infra_repo_existed: ${{ steps.create.outputs.repo_existed }}
@@ -355,7 +387,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 3. Open a per-run tracking issue in the infrastructure repository.
+  # 4. Open a per-run tracking issue in the infrastructure repository.
   #     Created right after the infra repo is available (new or existing). A
   #     follow-up comment with the full infrastructure summary (plan results,
   #     verify counts) is posted by comment-infra-issue after apply + verify.
@@ -423,7 +455,7 @@ jobs:
           echo "number=$NUMBER"  >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 4. Checkov – security and compliance scan, per target environment
+  # 5. Checkov – security and compliance scan, per target environment
   #    Per-env scoping lets us keep prod-strict baselines (ALB deletion
   #    protection, restrictive security groups) while allowing dev/staging to
   #    run lighter, faster-to-tear-down footprints.
@@ -466,7 +498,7 @@ jobs:
           category:        checkov-terraform-${{ matrix.environment }}
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 5. Terraform format check (once, not per-environment)
+  # 6. Terraform format check (once, not per-environment)
   # ────────────────────────────────────────────────────────────────────────────
   fmt:
     name: Terraform fmt check
@@ -491,7 +523,7 @@ jobs:
         run: terraform fmt -check -recursive infra-repo/terraform/
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 6. Bootstrap remote state storage (idempotent – safe to run every time).
+  # 7. Bootstrap remote state storage (idempotent – safe to run every time).
   #    Delegates to the reusable bootstrap-tfstate-aws.yml workflow so the same
   #    logic can be triggered standalone.
   # ────────────────────────────────────────────────────────────────────────────
@@ -506,7 +538,7 @@ jobs:
       aws_account_id: ${{ needs.resolve-inputs.outputs.aws_account_id }}
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 7. Terraform plan – one job per target environment, after scan passes
+  # 8. Terraform plan – one job per target environment, after scan passes
   # ────────────────────────────────────────────────────────────────────────────
   plan:
     name: "Plan · ${{ matrix.environment }}"
@@ -617,7 +649,7 @@ jobs:
             infra-repo/terraform/environments/${{ matrix.environment }}/plan-output.txt
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 8. Terraform apply – consume the plan artifact and provision per environment
+  # 9. Terraform apply – consume the plan artifact and provision per environment
   # ────────────────────────────────────────────────────────────────────────────
   apply:
     name: "Apply · ${{ matrix.environment }}"
@@ -711,7 +743,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 9. Verify – delegates to the reusable verify-infrastructure-aws.yml
+  # 10. Verify – delegates to the reusable verify-infrastructure-aws.yml
   #    workflow. The reusable workflow owns the GitHub Environment binding and
   #    the OIDC login, so trust-policy subject matching stays consistent
   #    whether verify runs from here or is triggered standalone.
@@ -741,7 +773,7 @@ jobs:
       gh_pat: ${{ secrets.GH_PAT }}
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 10. Application repository – create from template (idempotent).
+  # 11. Application repository – create from template (idempotent).
   #
   #    The workflow can be re-invoked any number of times — typically once per
   #    environment as it is rolled out. On re-runs the repo already exists and
@@ -881,7 +913,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 11. Per-run tracking issue in the application repository. Covers only
+  # 12. Per-run tracking issue in the application repository. Covers only
   #     app-specific outcomes: whether the repo was created or already existed,
   #     and (via a follow-up comment) env config and CI/CD results.
   #     Infrastructure details are tracked separately in the infra repo issue.
@@ -950,7 +982,7 @@ jobs:
           echo "number=$NUMBER"  >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 12. Comment on the infra repo issue with the full infrastructure summary:
+  # 13. Comment on the infra repo issue with the full infrastructure summary:
   #      per-env terraform plan results, verification test counts, and whether
   #      this run was a provision or reconcile. Runs after apply + verify.
   # ────────────────────────────────────────────────────────────────────────────
@@ -1091,7 +1123,7 @@ jobs:
           fi
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 13. Configure GitHub Environments and variables — one job per environment.
+  # 14. Configure GitHub Environments and variables — one job per environment.
   #     Always runs (idempotent: PUT for the env, PATCH→POST for each variable)
   #     so re-invocations can roll out additional envs to an existing app repo.
   # ────────────────────────────────────────────────────────────────────────────
@@ -1145,7 +1177,7 @@ jobs:
           echo "Environment '${ENV}' configured on ${REPO_FULL}"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 14. Register the app repo's OIDC subject on the IAM role's trust policy so
+  # 15. Register the app repo's OIDC subject on the IAM role's trust policy so
   #      tokens issued for the new repo are accepted by STS. Without this,
   #      deploy.yml in the new repo fails on aws-actions/configure-aws-credentials
   #      with "Not authorized to perform sts:AssumeRoleWithWebIdentity".
@@ -1285,7 +1317,7 @@ jobs:
           echo "Registered trust subject '${SUBJECT}' on role '${ROLE_NAME}'"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 15. Observe the CI run that template-generation auto-triggered.
+  # 16. Observe the CI run that template-generation auto-triggered.
   #
   #     When a repo is created from a template, GitHub pushes the initial
   #     commit to `main` and any `on: push` workflows fire automatically. So
@@ -1342,7 +1374,7 @@ jobs:
           echo "CI run #${CI_RUN_ID} succeeded: ${CI_RUN_URL}"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 16. Comment on the app repo issue with the app-specific run summary:
+  # 17. Comment on the app repo issue with the app-specific run summary:
   #     env config result, OIDC trust, CI/CD run. Waits for
   #     configure-environments and configure-oidc-trust so their results are
   #     available even on reconcile runs (where observe-ci is skipped and would
@@ -1413,7 +1445,7 @@ jobs:
           fi
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 17. Write the consolidated platform-side step summary once both issue
+  # 18. Write the consolidated platform-side step summary once both issue
   #     comments have been posted. Links out to the per-repo issues where the
   #     full run details live.
   # ────────────────────────────────────────────────────────────────────────────

--- a/.github/workflows/provision-infrastructure.yml
+++ b/.github/workflows/provision-infrastructure.yml
@@ -248,11 +248,45 @@ jobs:
           EOF
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 2. Create infrastructure repository from template (idempotent)
+  # 2. Preflight existence checks — confirm the template repos (and any
+  #    pinned refs) exist and the container image is anonymously pullable
+  #    BEFORE anything is created. A mistyped value otherwise only surfaces
+  #    as a checkout failure mid-run — or worse, as a service waiting forever
+  #    for an image it can never pull. All findings are reported together in
+  #    the job summary. Gating create-infra-repo gates the entire downstream
+  #    graph, so nothing runs on bad inputs.
+  #
+  #    The repo checks use GH_PAT when configured (proving the accessibility
+  #    the app phase will need) and fall back to the workflow token, keeping
+  #    infra-only setups PAT-free as documented in setup-github.md.
+  # ────────────────────────────────────────────────────────────────────────────
+  preflight:
+    name: Preflight checks
+    needs: resolve-inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for helper script)
+        uses: actions/checkout@v6
+
+      - name: Verify template repos and container image
+        env:
+          GH_TOKEN:            ${{ secrets.GH_PAT || github.token }}
+          INFRA_TEMPLATE_REPO: ${{ needs.resolve-inputs.outputs.infra_template_repo }}
+          INFRA_TEMPLATE_REF:  ${{ needs.resolve-inputs.outputs.infra_template_ref }}
+          APP_TEMPLATE_REPO:   ${{ needs.resolve-inputs.outputs.app_template_repo }}
+          APP_TEMPLATE_REF:    ${{ needs.resolve-inputs.outputs.app_template_ref }}
+          IMAGE:               ${{ needs.resolve-inputs.outputs.container_image }}
+          REGISTRY:            ${{ needs.resolve-inputs.outputs.container_registry_url }}
+        run: |
+          export CONTAINER_IMAGE_FULL="${REGISTRY:+${REGISTRY}/}${IMAGE}"
+          scripts/preflight-inputs.sh
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # 3. Create infrastructure repository from template (idempotent)
   # ────────────────────────────────────────────────────────────────────────────
   create-infra-repo:
     name: Create infrastructure repo
-    needs: resolve-inputs
+    needs: [resolve-inputs, preflight]
     runs-on: ubuntu-latest
     outputs:
       infra_repo_existed: ${{ steps.create.outputs.repo_existed }}
@@ -348,7 +382,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 3. Open a per-run tracking issue in the infrastructure repository.
+  # 4. Open a per-run tracking issue in the infrastructure repository.
   #     Created right after the infra repo is available (new or existing). A
   #     follow-up comment with the full infrastructure summary (plan results,
   #     verify counts) is posted by comment-infra-issue after apply + verify.
@@ -416,7 +450,7 @@ jobs:
           echo "number=$NUMBER"  >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 4. Checkov – security and compliance scan, per target environment
+  # 5. Checkov – security and compliance scan, per target environment
   #    Per-env scoping lets us keep prod-strict baselines (zone redundancy, min
   #    instance count) while allowing dev/staging to run lighter footprints.
   # ────────────────────────────────────────────────────────────────────────────
@@ -458,7 +492,7 @@ jobs:
           category:        checkov-terraform-${{ matrix.environment }}
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 5. Terraform format check (once, not per-environment)
+  # 6. Terraform format check (once, not per-environment)
   # ────────────────────────────────────────────────────────────────────────────
   fmt:
     name: Terraform fmt check
@@ -483,7 +517,7 @@ jobs:
         run: terraform fmt -check -recursive infra-repo/terraform/
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 6. Bootstrap remote state storage (idempotent – safe to run every time).
+  # 7. Bootstrap remote state storage (idempotent – safe to run every time).
   #    Delegates to the reusable bootstrap-tfstate.yml workflow so the same
   #    logic can be triggered standalone.
   # ────────────────────────────────────────────────────────────────────────────
@@ -499,7 +533,7 @@ jobs:
       azure_location:        ${{ needs.resolve-inputs.outputs.azure_location }}
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 7. Terraform plan – one job per target environment, after scan passes
+  # 8. Terraform plan – one job per target environment, after scan passes
   # ────────────────────────────────────────────────────────────────────────────
   plan:
     name: "Plan · ${{ matrix.environment }}"
@@ -626,7 +660,7 @@ jobs:
             infra-repo/terraform/environments/${{ matrix.environment }}/plan-output.txt
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 8. Terraform apply – consume the plan artifact and provision per environment
+  # 9. Terraform apply – consume the plan artifact and provision per environment
   # ────────────────────────────────────────────────────────────────────────────
   apply:
     name: "Apply · ${{ matrix.environment }}"
@@ -731,7 +765,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 9. Verify – delegates to the reusable verify-infrastructure.yml workflow.
+  # 10. Verify – delegates to the reusable verify-infrastructure.yml workflow.
   #    The reusable workflow owns the GitHub Environment binding and the
   #    OIDC login, so federated credential matching stays consistent whether
   #    verify runs from here or is triggered standalone.
@@ -759,7 +793,7 @@ jobs:
       gh_pat: ${{ secrets.GH_PAT }}
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 10. Application repository – create from template (idempotent).
+  # 11. Application repository – create from template (idempotent).
   #
   #    The workflow can be re-invoked any number of times — typically once per
   #    environment as it is rolled out. On re-runs the repo already exists and
@@ -900,7 +934,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 11. Per-run tracking issue in the application repository. Covers only
+  # 12. Per-run tracking issue in the application repository. Covers only
   #     app-specific outcomes: whether the repo was created or already existed,
   #     and (via a follow-up comment from finalize) env config and CI/CD results.
   #     Infrastructure details are tracked separately in the infra repo issue.
@@ -969,7 +1003,7 @@ jobs:
           echo "number=$NUMBER"  >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 12. Comment on the infra repo issue with the full infrastructure summary:
+  # 13. Comment on the infra repo issue with the full infrastructure summary:
   #      per-env terraform plan results, verification test counts, and whether
   #      this run was a provision or reconcile. Runs after apply + verify.
   # ────────────────────────────────────────────────────────────────────────────
@@ -1110,7 +1144,7 @@ jobs:
           fi
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 13. Configure GitHub Environments and variables — one job per environment.
+  # 14. Configure GitHub Environments and variables — one job per environment.
   #     Always runs (idempotent: PUT for the env, PATCH→POST for each variable)
   #     so re-invocations can roll out additional envs to an existing app repo.
   # ────────────────────────────────────────────────────────────────────────────
@@ -1165,7 +1199,7 @@ jobs:
           echo "Environment '${ENV}' configured on ${REPO_FULL}"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 14. Register federated credentials on the platform-eng App Registration so
+  # 15. Register federated credentials on the platform-eng App Registration so
   #      OIDC tokens issued for the new app repo are accepted by Entra ID.
   #      Without these, deploy.yml in the new repo fails on `azure/login` with
   #      AADSTS700213 ("No matching federated identity record found").
@@ -1283,7 +1317,7 @@ jobs:
           echo "Registered federated credential '${NAME}' for subject '${SUBJECT}'"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 15. Observe the CI run that template-generation auto-triggered.
+  # 16. Observe the CI run that template-generation auto-triggered.
   #
   #     When a repo is created from a template, GitHub pushes the initial
   #     commit to `main` and any `on: push` workflows fire automatically. So
@@ -1340,7 +1374,7 @@ jobs:
           echo "CI run #${CI_RUN_ID} succeeded: ${CI_RUN_URL}"
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 16. Comment on the app repo issue with the app-specific run summary:
+  # 17. Comment on the app repo issue with the app-specific run summary:
   #     env config result, federated credentials, CI/CD run. Waits for
   #     configure-environments and configure-federated-credentials so their
   #     results are available even on reconcile runs (where observe-ci is
@@ -1411,7 +1445,7 @@ jobs:
           fi
 
   # ────────────────────────────────────────────────────────────────────────────
-  # 17. Write the consolidated platform-side step summary once both issue
+  # 18. Write the consolidated platform-side step summary once both issue
   #     comments have been posted. Links out to the per-repo issues where the
   #     full run details live.
   # ────────────────────────────────────────────────────────────────────────────

--- a/docs/index.md
+++ b/docs/index.md
@@ -222,6 +222,7 @@ operator                ┌─────────────────�
 ├── scripts/                                 # cloud-specific scripts carry an -azure / -aws suffix
 │   ├── bootstrap-tfstate-azure.sh           # Idempotent az-cli state bootstrap (storage account)
 │   ├── bootstrap-tfstate-aws.sh             # Idempotent aws-cli state bootstrap (S3 bucket)
+│   ├── preflight-inputs.sh                  # Existence checks for template repos + container image (cloud-agnostic)
 │   ├── tag-app-resources-azure.sh           # Merge an arbitrary tag set onto all app resources
 │   ├── tag-app-resources-aws.sh             # Same, via the Resource Groups Tagging API
 │   ├── trigger-provision-azure.sh           # CLI wrapper around repository_dispatch

--- a/docs/setup-aws.md
+++ b/docs/setup-aws.md
@@ -93,7 +93,7 @@ policy. You need **four** subjects because two different formats apply:
 
 | Subject | Used by |
 |---------|---------|
-| `repo:<org>/<repo>:ref:refs/heads/main` | every job in `provision-infrastructure-aws.yml` **without** an `environment:` key — `resolve-inputs`, `fmt`, `checkov`, `bootstrap-tfstate`, `create-app-repo`, `create-run-issue`, `configure-environments`, `configure-oidc-trust`, `observe-ci`, `final-summary`; and the standalone `bootstrap-tfstate-aws.yml`, `detect-drift-aws.yml`, `tag-app-resources-aws.yml` and delete workflows |
+| `repo:<org>/<repo>:ref:refs/heads/main` | every job in `provision-infrastructure-aws.yml` **without** an `environment:` key — `resolve-inputs`, `preflight`, `fmt`, `checkov`, `bootstrap-tfstate`, `create-app-repo`, `create-run-issue`, `configure-environments`, `configure-oidc-trust`, `observe-ci`, `final-summary`; and the standalone `bootstrap-tfstate-aws.yml`, `detect-drift-aws.yml`, `tag-app-resources-aws.yml` and delete workflows |
 | `repo:<org>/<repo>:environment:dev` | every job pinned to `environment: dev` — `plan`, `apply`, the `verify-infrastructure-aws.yml` reusable workflow |
 | `repo:<org>/<repo>:environment:staging` | same set of jobs, pinned to `environment: staging` |
 | `repo:<org>/<repo>:environment:prod` | same set of jobs, pinned to `environment: prod` |
@@ -310,6 +310,7 @@ marked _(app phase)_ only appear when `app_template_repo` is provided.
 
 ```
 Resolve inputs                    ✓ validated inputs, derived tf-state-<app>-<acct8> from the role ARN
+Preflight checks                  ✓ template repos + pinned refs exist, container image anonymously pullable
 Checkov · {env}                   ✓ no findings
 Terraform fmt check               ✓ formatting clean
 Bootstrap tfstate bucket          ✓ S3 bucket + rg-test-webapp-tfstate resource group

--- a/docs/setup-azure.md
+++ b/docs/setup-azure.md
@@ -107,7 +107,7 @@ You need **four** credentials because two different subject formats apply:
 
 | Credential | Used by | Subject |
 |------------|---------|---------|
-| Branch-scoped | every job in `provision-infrastructure.yml` **without** an `environment:` key — `resolve-inputs`, `fmt`, `checkov`, `bootstrap-tfstate`, `create-app-repo`, `create-run-issue`, `configure-environments`, `configure-federated-credentials`, `observe-ci`, `finalize`; and the standalone `bootstrap-tfstate.yml` | `repo:<org>/<repo>:ref:refs/heads/main` |
+| Branch-scoped | every job in `provision-infrastructure.yml` **without** an `environment:` key — `resolve-inputs`, `preflight`, `fmt`, `checkov`, `bootstrap-tfstate`, `create-app-repo`, `create-run-issue`, `configure-environments`, `configure-federated-credentials`, `observe-ci`, `finalize`; and the standalone `bootstrap-tfstate.yml` | `repo:<org>/<repo>:ref:refs/heads/main` |
 | Environment `dev` | every job pinned to `environment: dev` — `plan`, `apply`, the `verify-infrastructure.yml` reusable workflow | `repo:<org>/<repo>:environment:dev` |
 | Environment `staging` | same set of jobs, pinned to `environment: staging` | `repo:<org>/<repo>:environment:staging` |
 | Environment `prod` | same set of jobs, pinned to `environment: prod` | `repo:<org>/<repo>:environment:prod` |
@@ -412,6 +412,7 @@ marked _(app phase)_ only appear when `app_template_repo` is provided.
 
 ```
 Resolve inputs                    ✓ validated inputs, derived sttf<app><sub>
+Preflight checks                  ✓ template repos + pinned refs exist, container image anonymously pullable
 Checkov · {env}                   ✓ no findings
 Terraform fmt check               ✓ formatting clean
 Bootstrap tfstate storage         ✓ rg-test-webapp-tfstate + storage account + container

--- a/scripts/preflight-inputs.sh
+++ b/scripts/preflight-inputs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# preflight-inputs.sh — fail-fast existence checks for the provisioning
+# workflows (P15). Confirms, BEFORE anything is created:
+#
+#   1. the infrastructure template repo exists and is accessible
+#   2. its pinned ref (when provided) resolves to a commit
+#   3. the application template repo and ref, likewise (when provided)
+#   4. the container image manifest exists and is anonymously pullable —
+#      the same access mode ECS / App Service uses on first deploy, so a
+#      mistyped image fails here with a named error instead of a service
+#      waiting forever for an image it can never pull
+#
+# Every check runs; ALL failures are reported together — one ::error::
+# annotation per finding plus a table in the job summary — and the script
+# exits non-zero if any check failed.
+#
+# Inputs via environment:
+#   INFRA_TEMPLATE_REPO   owner/name                                (required)
+#   INFRA_TEMPLATE_REF    git ref pinning it, or empty
+#   APP_TEMPLATE_REPO     owner/name, or empty (infra-only run)
+#   APP_TEMPLATE_REF      git ref pinning it, or empty
+#   CONTAINER_IMAGE_FULL  full image reference incl. registry host  (required)
+#   GH_TOKEN              token for the repo checks — the same one the run
+#                         uses later, so success here proves accessibility
+#
+# Requires: gh, docker (both preinstalled on ubuntu-latest runners).
+
+# Deliberately NOT set -e: every check must run so the report is complete.
+set -uo pipefail
+
+RESULTS=()   # "status<TAB>check<TAB>detail" rows for the summary table
+FAILED=0
+
+note_ok () { RESULTS+=("✅	$1	$2"); echo "ok:   $1 — $2"; }
+note_fail () {
+  # Keep the detail single-line and free of '|' so the summary table renders.
+  local detail; detail=$(tr '\n' ' ' <<<"$2" | tr '|' '/')
+  RESULTS+=("❌	$1	${detail}")
+  echo "::error::Preflight: $1 — ${detail}"
+  FAILED=1
+}
+
+# ── 1+2/3: template repositories and their pinned refs ──────────────────────
+check_repo_and_ref () {
+  local label="$1" repo="$2" ref="$3" err sha
+  if ! err=$(gh api "repos/${repo}" --jq .full_name 2>&1 >/dev/null); then
+    if grep -q "HTTP 404" <<<"${err}"; then
+      note_fail "${label} repo" "'${repo}' not found, or not accessible with the workflow's token — check the owner/name spelling"
+    else
+      note_fail "${label} repo" "could not verify '${repo}': ${err}"
+    fi
+    return   # the ref cannot be checked without the repo
+  fi
+  note_ok "${label} repo" "'${repo}' exists and is accessible"
+
+  if [[ -n "${ref}" ]]; then
+    # commits/<ref> resolves branches, tags and commit SHAs alike.
+    if sha=$(gh api "repos/${repo}/commits/${ref}" --jq .sha 2>/dev/null); then
+      note_ok "${label} ref" "'${ref}' resolves to ${sha:0:7}"
+    else
+      note_fail "${label} ref" "'${ref}' does not resolve in '${repo}' — expected an existing tag, branch or commit SHA"
+    fi
+  fi
+}
+
+check_repo_and_ref "infra template" "${INFRA_TEMPLATE_REPO}" "${INFRA_TEMPLATE_REF:-}"
+
+if [[ -n "${APP_TEMPLATE_REPO:-}" ]]; then
+  check_repo_and_ref "app template" "${APP_TEMPLATE_REPO}" "${APP_TEMPLATE_REF:-}"
+else
+  note_ok "app template" "not provided — infra-only run, check skipped"
+fi
+
+# ── 4: container image manifest, anonymously ────────────────────────────────
+# `docker manifest inspect` queries the registry without pulling layers and
+# without credentials — exactly how the infrastructure pulls a public image
+# on first deploy. GH_TOKEN is unset for this call so a docker login from an
+# earlier step can never mask an image that is not actually public.
+# Tooling absence must fail as a tooling error, never as "image not found".
+if ! command -v docker >/dev/null; then
+  note_fail "container image" "docker CLI not available on this runner — the image check could not run at all (this is a tooling problem, not a verdict on '${CONTAINER_IMAGE_FULL}')"
+elif OUT=$(docker manifest inspect "${CONTAINER_IMAGE_FULL}" 2>&1 >/dev/null); then
+  note_ok "container image" "'${CONTAINER_IMAGE_FULL}' manifest found — anonymously pullable"
+else
+  note_fail "container image" "'${CONTAINER_IMAGE_FULL}' manifest not found or not anonymously accessible — the first deploy would wait forever for an image it cannot pull. Registry said: ${OUT}"
+fi
+
+# ── Report ───────────────────────────────────────────────────────────────────
+{
+  echo "## Preflight checks"
+  echo ""
+  echo "| Result | Check | Detail |"
+  echo "|--------|-------|--------|"
+  for row in "${RESULTS[@]}"; do
+    IFS=$'\t' read -r s c d <<<"${row}"
+    echo "| ${s} | ${c} | ${d} |"
+  done
+  echo ""
+  if [[ "${FAILED}" -eq 1 ]]; then
+    echo "> One or more inputs failed verification. Nothing was created — fix the values above and re-run."
+  fi
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+exit "${FAILED}"


### PR DESCRIPTION
Adds a preflight job to both provisioning workflows, between resolve-inputs and create-infra-repo, backed by a shared cloud-agnostic script (scripts/preflight-inputs.sh). Before anything is created it confirms:

- the infra template repo exists and is accessible (and its pinned ref resolves), using GH_PAT when configured with a workflow-token fallback so infra-only setups stay PAT-free
- same for the app template repo/ref, when provided
- the container image manifest exists and is anonymously pullable (docker manifest inspect) — the same access mode the first deploy uses, so a mistyped image fails here instead of a service waiting forever

All checks run in one pass and every failure is reported together, as ::error:: annotations plus a job-summary table. Gating create-infra-repo gates the entire downstream graph, so nothing runs on bad inputs.

Closes #52 (P15).