### PR TITLE
feat: environment promotion gate in preflight (staging needs dev, pro…

### DIFF
--- a/.github/workflows/provision-infrastructure-aws.yml
+++ b/.github/workflows/provision-infrastructure-aws.yml
@@ -266,6 +266,9 @@ jobs:
   #    The repo checks use GH_PAT when configured (proving the accessibility
   #    the app phase will need) and fall back to the workflow token, keeping
   #    infra-only setups PAT-free as documented in setup-github.md.
+  #
+  #    The job also enforces the environment promotion order (P16): staging
+  #    cannot be first-provisioned before dev, nor prod before dev + staging.
   # ────────────────────────────────────────────────────────────────────────────
   preflight:
     name: Preflight checks
@@ -285,6 +288,78 @@ jobs:
           CONTAINER_IMAGE_FULL: ${{ needs.resolve-inputs.outputs.container_image }}
         run: |
           scripts/preflight-inputs.sh
+
+      # The promotion gate below reads the tfstate backend, which needs a
+      # cloud login. This job never binds a GitHub Environment, so the
+      # branch-scoped trust subject authenticates it — the same subject
+      # every other non-environment job uses.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ needs.resolve-inputs.outputs.aws_role_arn }}
+          aws-region:     ${{ needs.resolve-inputs.outputs.aws_region }}
+
+      - name: Environment promotion gate
+        env:
+          ENVS_JSON: ${{ needs.resolve-inputs.outputs.environments }}
+          BUCKET:    ${{ needs.resolve-inputs.outputs.tfstate_bucket }}
+        run: |
+          set -euo pipefail
+
+          # Promotion order is dev → staging → prod: staging cannot be
+          # first-provisioned before dev, nor prod before dev + staging. A
+          # prerequisite counts as satisfied when it is part of this same
+          # request (so 'all' always passes, with no lookups) or already
+          # provisioned. Reconciling an environment that already exists is
+          # always allowed, even if a prerequisite has since been deleted —
+          # the gate orders FIRST provisioning, it does not police steady
+          # state. "Already provisioned" is judged from the tfstate backend,
+          # the only signal that also works for infra-only runs.
+          ENVS=$(jq -r '.[]' <<<"$ENVS_JSON")
+          in_set() { grep -qx "$1" <<<"$ENVS"; }
+
+          exists() {
+            local KEY="$1/terraform.tfstate" OUT N
+            # Classify failures: a missing bucket/object means "not
+            # provisioned", but an auth or transport error must fail the gate
+            # loudly — never be misread as "environment missing".
+            if ! OUT=$(aws s3api head-object --bucket "$BUCKET" --key "$KEY" 2>&1 >/dev/null); then
+              if grep -qiE "404|Not Found|NoSuchBucket|NoSuchKey" <<<"$OUT"; then
+                return 1
+              fi
+              echo "::error::Environment promotion gate could not check '$1' (state backend query failed): ${OUT}"
+              exit 1
+            fi
+            # A deleted AWS environment deliberately leaves an accurate-EMPTY
+            # state object behind (unlike Azure, which removes the blob), so
+            # presence alone is not proof: the state must actually track
+            # resources. Only the resource count is read — state contents are
+            # never printed.
+            N=$(aws s3 cp "s3://${BUCKET}/${KEY}" - 2>/dev/null | jq '.resources | length' 2>/dev/null || echo 0)
+            [[ "$N" -gt 0 ]]
+          }
+
+          require() {
+            local TARGET="$1"; shift
+            in_set "$TARGET" || return 0
+            local MISSING=()
+            for P in "$@"; do
+              in_set "$P" && continue
+              exists "$P" && continue
+              MISSING+=("$P")
+            done
+            [[ ${#MISSING[@]} -eq 0 ]] && return 0
+            if exists "$TARGET"; then
+              echo "'$TARGET' is already provisioned — reconcile allowed although prerequisite(s) no longer exist: ${MISSING[*]}"
+              return 0
+            fi
+            echo "::error::Environment promotion gate: '$TARGET' requested, but prerequisite environment(s) not provisioned yet: ${MISSING[*]}. Provision ${MISSING[*]} first, or request 'all'."
+            exit 1
+          }
+
+          require staging dev
+          require prod dev staging
+          echo "Environment promotion gate passed."
 
   # ────────────────────────────────────────────────────────────────────────────
   # 3. Create infrastructure repository from template (idempotent)

--- a/.github/workflows/provision-infrastructure.yml
+++ b/.github/workflows/provision-infrastructure.yml
@@ -259,6 +259,9 @@ jobs:
   #    The repo checks use GH_PAT when configured (proving the accessibility
   #    the app phase will need) and fall back to the workflow token, keeping
   #    infra-only setups PAT-free as documented in setup-github.md.
+  #
+  #    The job also enforces the environment promotion order (P16): staging
+  #    cannot be first-provisioned before dev, nor prod before dev + staging.
   # ────────────────────────────────────────────────────────────────────────────
   preflight:
     name: Preflight checks
@@ -280,6 +283,78 @@ jobs:
         run: |
           export CONTAINER_IMAGE_FULL="${REGISTRY:+${REGISTRY}/}${IMAGE}"
           scripts/preflight-inputs.sh
+
+      # The promotion gate below reads the tfstate backend, which needs a
+      # cloud login. This job never binds a GitHub Environment, so the
+      # branch-scoped federated credential authenticates it — the same
+      # subject every other non-environment job uses.
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          tenant-id:       ${{ needs.resolve-inputs.outputs.azure_tenant_id }}
+          subscription-id: ${{ needs.resolve-inputs.outputs.azure_subscription_id }}
+          client-id:       ${{ needs.resolve-inputs.outputs.azure_client_id }}
+
+      - name: Environment promotion gate
+        env:
+          ENVS_JSON:       ${{ needs.resolve-inputs.outputs.environments }}
+          STORAGE_ACCOUNT: ${{ needs.resolve-inputs.outputs.tfstate_storage_account }}
+        run: |
+          set -euo pipefail
+
+          # Promotion order is dev → staging → prod: staging cannot be
+          # first-provisioned before dev, nor prod before dev + staging. A
+          # prerequisite counts as satisfied when it is part of this same
+          # request (so 'all' always passes, with no lookups) or already
+          # provisioned. Reconciling an environment that already exists is
+          # always allowed, even if a prerequisite has since been deleted —
+          # the gate orders FIRST provisioning, it does not police steady
+          # state. "Already provisioned" is judged from the tfstate backend,
+          # the only signal that also works for infra-only runs.
+          ENVS=$(jq -r '.[]' <<<"$ENVS_JSON")
+          in_set() { grep -qx "$1" <<<"$ENVS"; }
+
+          exists() {
+            local BLOB="$1/terraform.tfstate" OUT
+            # Classify failures: a missing account/container means "not
+            # provisioned", but an auth or transport error must fail the gate
+            # loudly — never be misread as "environment missing".
+            if ! OUT=$(az storage blob exists \
+                         --account-name   "$STORAGE_ACCOUNT" \
+                         --container-name tfstate \
+                         --name           "$BLOB" \
+                         --auth-mode      login \
+                         --query exists --output tsv 2>&1); then
+              if grep -qiE "ResourceNotFound|StorageAccountNotFound|ContainerNotFound|does not exist|not found" <<<"$OUT"; then
+                return 1
+              fi
+              echo "::error::Environment promotion gate could not check '$1' (state backend query failed): ${OUT}"
+              exit 1
+            fi
+            [[ "$OUT" == "true" ]]
+          }
+
+          require() {
+            local TARGET="$1"; shift
+            in_set "$TARGET" || return 0
+            local MISSING=()
+            for P in "$@"; do
+              in_set "$P" && continue
+              exists "$P" && continue
+              MISSING+=("$P")
+            done
+            [[ ${#MISSING[@]} -eq 0 ]] && return 0
+            if exists "$TARGET"; then
+              echo "'$TARGET' is already provisioned — reconcile allowed although prerequisite(s) no longer exist: ${MISSING[*]}"
+              return 0
+            fi
+            echo "::error::Environment promotion gate: '$TARGET' requested, but prerequisite environment(s) not provisioned yet: ${MISSING[*]}. Provision ${MISSING[*]} first, or request 'all'."
+            exit 1
+          }
+
+          require staging dev
+          require prod dev staging
+          echo "Environment promotion gate passed."
 
   # ────────────────────────────────────────────────────────────────────────────
   # 3. Create infrastructure repository from template (idempotent)

--- a/docs/setup-aws.md
+++ b/docs/setup-aws.md
@@ -287,7 +287,7 @@ Resources → Run workflow**, and provide:
 | Input | Required | Value for the first test |
 | ----- | -------- | ------------------------ |
 | `app_name` | yes | `test-webapp` (3–22 chars, lowercase, digits, hyphens) |
-| `environment` | yes | `dev` |
+| `environment` | yes | `dev` — promotion order is enforced: `staging` can only be requested once `dev` is provisioned, `prod` once `dev` and `staging` both are ready (requesting `all`, or reconciling an environment that already exists, always passes) |
 | `aws_region` | yes | `eu-west-1` — region for the tfstate bucket and every provisioned resource. No default, by design: an implicit region silently deploys to the wrong place |
 | `aws_role_arn` | yes | the role ARN captured in step 2 |
 | `main_domain` | yes | the root domain of your Route 53 public hosted zone (e.g. `example.com`) — drives the ACM certificate and DNS records for `<app>.<env>.<domain>` |
@@ -310,7 +310,7 @@ marked _(app phase)_ only appear when `app_template_repo` is provided.
 
 ```
 Resolve inputs                    ✓ validated inputs, derived tf-state-<app>-<acct8> from the role ARN
-Preflight checks                  ✓ template repos + pinned refs exist, container image anonymously pullable
+Preflight checks                  ✓ template repos + pinned refs exist, container image anonymously pullable, environment promotion order respected
 Checkov · {env}                   ✓ no findings
 Terraform fmt check               ✓ formatting clean
 Bootstrap tfstate bucket          ✓ S3 bucket + rg-test-webapp-tfstate resource group

--- a/docs/setup-azure.md
+++ b/docs/setup-azure.md
@@ -392,7 +392,7 @@ Resources → Run workflow**, and provide:
 | Input | Required | Value for the first test |
 | ----- | -------- | ------------------------ |
 | `app_name` | yes | `test-webapp` (3–22 chars, lowercase, digits, hyphens) |
-| `environment` | yes | `dev` |
+| `environment` | yes | `dev` — promotion order is enforced: `staging` can only be requested once `dev` is provisioned, `prod` once `dev` and `staging` both are ready (requesting `all`, or reconciling an environment that already exists, always passes) |
 | `azure_tenant_id` | yes | the tenant GUID captured in step 1 |
 | `azure_subscription_id` | yes | the GUID captured in step 1 |
 | `azure_client_id` | yes | the `appId` captured in step 1 |
@@ -412,7 +412,7 @@ marked _(app phase)_ only appear when `app_template_repo` is provided.
 
 ```
 Resolve inputs                    ✓ validated inputs, derived sttf<app><sub>
-Preflight checks                  ✓ template repos + pinned refs exist, container image anonymously pullable
+Preflight checks                  ✓ template repos + pinned refs exist, container image anonymously pullable, environment promotion order respected
 Checkov · {env}                   ✓ no findings
 Terraform fmt check               ✓ formatting clean
 Bootstrap tfstate storage         ✓ rg-test-webapp-tfstate + storage account + container


### PR DESCRIPTION
…d needs dev+staging)

Requesting staging or prod for an app whose earlier environments were never provisioned used to surface only later, as a failing first CI/CD run. The preflight job now enforces the promotion order while inputs are checked, in both provisioning workflows:

- staging cannot be first-provisioned unless dev already exists; prod unless dev and staging both exist
- a prerequisite in the same request also counts, so 'all' passes with no lookups (as does a dev-only request)
- reconciling an environment that already exists is always allowed, even if a prerequisite has since been deleted — the gate orders first provisioning, it does not police steady state
- "already provisioned" is judged from the tfstate backend (works for infra-only runs too): blob existence on Azure; on AWS the state object must also track at least one resource, because a deleted environment deliberately leaves an accurate-empty state object behind
- backend query errors fail the gate loudly instead of reading as "environment missing"

The preflight job gains the OIDC cloud login this needs, authenticated by the branch-scoped subject like every other non-environment job. Docs: the ordering rule is stated on the environment input row and the preflight line of both setup guides.

Closes #54 (P16).