### PR TITLE
feat: org-level cloud parameter defaults with per-run override

### DIFF
--- a/.github/workflows/provision-infrastructure-aws.yml
+++ b/.github/workflows/provision-infrastructure-aws.yml
@@ -13,14 +13,19 @@ on:
         options: [dev, staging, prod, all]
         required: true
         default: dev
+      # The two target-cloud parameters are optional ON PURPOSE, with no
+      # default: the target cloud is usually locked in for the organization,
+      # so each falls back to a PROVISION_* repository variable set once. An
+      # input always overrides the variable; when neither is present the run
+      # fails fast in resolve-inputs naming both ways to supply the value.
       aws_region:
-        description: "AWS region for all the resources and the tfstate bucket (e.g. eu-west-1)"
+        description: "AWS region for all the resources and the tfstate bucket, e.g. eu-west-1 (optional — falls back to the PROVISION_AWS_REGION repository variable)"
         type: string
-        required: true
+        required: false
       aws_role_arn:
-        description: "ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole)"
+        description: "ARN of the IAM role to assume via OIDC (optional — falls back to the PROVISION_AWS_ROLE_ARN repository variable)"
         type: string
-        required: true
+        required: false
       main_domain:
         description: "Root domain managed in Route 53 (e.g. example.com). The template issues a certificate for <app>.<env>.<main_domain>"
         type: string
@@ -128,12 +133,18 @@ jobs:
           RD_IMAGE:              ${{ github.event.client_payload.container_image }}
           RD_REGISTRY:           ${{ github.event.client_payload.container_registry_url }}
           RD_CI_FILE:            ${{ github.event.client_payload.ci_workflow_file }}
+          # Organization defaults for the target-cloud parameters (Actions
+          # repository variables). Inputs always override them.
+          VAR_REGION:            ${{ vars.PROVISION_AWS_REGION }}
+          VAR_ROLE_ARN:          ${{ vars.PROVISION_AWS_ROLE_ARN }}
           OWNER:                 ${{ github.repository_owner }}
         run: |
           APP_NAME="${WD_APP:-$RD_APP}"
           ENVIRONMENT="${WD_ENV:-$RD_ENV}"
-          AWS_REGION="${WD_REGION:-$RD_REGION}"
-          AWS_ROLE_ARN="${WD_ROLE_ARN:-$RD_ROLE_ARN}"
+          # Target-cloud parameters: input (either trigger) wins, the
+          # PROVISION_* repository variable is the organization's fallback.
+          AWS_REGION="${WD_REGION:-${RD_REGION:-$VAR_REGION}}"
+          AWS_ROLE_ARN="${WD_ROLE_ARN:-${RD_ROLE_ARN:-$VAR_ROLE_ARN}}"
           MAIN_DOMAIN="${WD_MAIN_DOMAIN:-$RD_MAIN_DOMAIN}"
           INFRA_TEMPLATE_REPO="${WD_INFRA_TEMPLATE:-$RD_INFRA_TEMPLATE}"
           INFRA_TEMPLATE_REF="${WD_INFRA_TEMPLATE_REF:-$RD_INFRA_TEMPLATE_REF}"
@@ -146,14 +157,46 @@ jobs:
           MISSING=()
           [[ -z "$APP_NAME"               ]] && MISSING+=(app_name)
           [[ -z "$ENVIRONMENT"            ]] && MISSING+=(environment)
-          [[ -z "$AWS_REGION"             ]] && MISSING+=(aws_region)
-          [[ -z "$AWS_ROLE_ARN"           ]] && MISSING+=(aws_role_arn)
           [[ -z "$MAIN_DOMAIN"            ]] && MISSING+=(main_domain)
           [[ -z "$INFRA_TEMPLATE_REPO"    ]] && MISSING+=(infra_template_repo)
           [[ -z "$CONTAINER_IMAGE"        ]] && MISSING+=(container_image)
           [[ -z "$CONTAINER_REGISTRY_URL" ]] && MISSING+=(container_registry_url)
-          if [[ ${#MISSING[@]} -gt 0 ]]; then
-            echo "::error::Missing required parameters: ${MISSING[*]}"
+
+          # Target-cloud parameters have TWO sources; when both are absent
+          # the report must name both, so they are tracked separately as
+          # "input_name|variable_name" pairs.
+          MISSING_CLOUD=()
+          [[ -z "$AWS_REGION"   ]] && MISSING_CLOUD+=("aws_region|PROVISION_AWS_REGION")
+          [[ -z "$AWS_ROLE_ARN" ]] && MISSING_CLOUD+=("aws_role_arn|PROVISION_AWS_ROLE_ARN")
+
+          if [[ ${#MISSING[@]} -gt 0 || ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            [[ ${#MISSING[@]} -gt 0 ]] && echo "::error::Missing required parameters: ${MISSING[*]}"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+              if [[ ${#MISSING[@]} -gt 0 ]]; then
+                echo "## Missing required parameters"
+                echo ""
+                for M in "${MISSING[@]}"; do echo "- \`${M}\`"; done
+                echo ""
+              fi
+              if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+                echo "## Missing target-cloud parameters"
+                echo ""
+                echo "The target cloud is usually locked in for the organization: set each"
+                echo "repository variable once, or pass the input to override it per run."
+                echo "An input always overrides the variable."
+                echo ""
+                echo "| Parameter | Pass per run as | …or set once as repository variable |"
+                echo "|-----------|-----------------|--------------------------------------|"
+                for M in "${MISSING_CLOUD[@]}"; do
+                  IFS='|' read -r IN VAR <<<"$M"
+                  echo "| \`${IN}\` | workflow input / \`client_payload.${IN}\` | \`gh variable set ${VAR}\` |"
+                done
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 

--- a/.github/workflows/provision-infrastructure.yml
+++ b/.github/workflows/provision-infrastructure.yml
@@ -13,22 +13,27 @@ on:
         options: [dev, staging, prod, all]
         required: true
         default: dev
+      # The four target-cloud parameters are optional ON PURPOSE, with no
+      # default: the target cloud is usually locked in for the organization,
+      # so each falls back to a PROVISION_* repository variable set once. An
+      # input always overrides the variable; when neither is present the run
+      # fails fast in resolve-inputs naming both ways to supply the value.
       azure_tenant_id:
-        description: "Azure Tenant ID"
+        description: "Azure Tenant ID (optional — falls back to the PROVISION_AZURE_TENANT_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_subscription_id:
-        description: "Azure Subscription ID"
+        description: "Azure Subscription ID (optional — falls back to the PROVISION_AZURE_SUBSCRIPTION_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_client_id:
-        description: "Client ID of the Azure service principal / managed identity used for OIDC login"
+        description: "Client ID of the service principal / managed identity for OIDC login (optional — falls back to the PROVISION_AZURE_CLIENT_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_location:
-        description: "Azure region for all the resources (e.g. westeurope)"
+        description: "Azure region for all the resources, e.g. westeurope (optional — falls back to the PROVISION_AZURE_LOCATION repository variable)"
         type: string
-        required: true
+        required: false
       infra_template_repo:
         description: "Template repo for the infrastructure (e.g. owner/template-terraform-azure-webapp)"
         type: string
@@ -135,14 +140,22 @@ jobs:
           RD_IMAGE:              ${{ github.event.client_payload.container_image }}
           RD_REGISTRY:           ${{ github.event.client_payload.container_registry_url }}
           RD_CI_FILE:            ${{ github.event.client_payload.ci_workflow_file }}
+          # Organization defaults for the target-cloud parameters (Actions
+          # repository variables). Inputs always override them.
+          VAR_TENANT_ID:         ${{ vars.PROVISION_AZURE_TENANT_ID }}
+          VAR_SUB_ID:            ${{ vars.PROVISION_AZURE_SUBSCRIPTION_ID }}
+          VAR_CLIENT_ID:         ${{ vars.PROVISION_AZURE_CLIENT_ID }}
+          VAR_AZURE_LOCATION:    ${{ vars.PROVISION_AZURE_LOCATION }}
           OWNER:                 ${{ github.repository_owner }}
         run: |
           APP_NAME="${WD_APP:-$RD_APP}"
           ENVIRONMENT="${WD_ENV:-$RD_ENV}"
-          AZURE_TENANT_ID="${WD_TENANT_ID:-$RD_TENANT_ID}"
-          AZURE_SUBSCRIPTION_ID="${WD_SUB_ID:-$RD_SUB_ID}"
-          AZURE_CLIENT_ID="${WD_CLIENT_ID:-$RD_CLIENT_ID}"
-          AZURE_LOCATION="${WD_AZURE_LOCATION:-$RD_AZURE_LOCATION}"
+          # Target-cloud parameters: input (either trigger) wins, the
+          # PROVISION_* repository variable is the organization's fallback.
+          AZURE_TENANT_ID="${WD_TENANT_ID:-${RD_TENANT_ID:-$VAR_TENANT_ID}}"
+          AZURE_SUBSCRIPTION_ID="${WD_SUB_ID:-${RD_SUB_ID:-$VAR_SUB_ID}}"
+          AZURE_CLIENT_ID="${WD_CLIENT_ID:-${RD_CLIENT_ID:-$VAR_CLIENT_ID}}"
+          AZURE_LOCATION="${WD_AZURE_LOCATION:-${RD_AZURE_LOCATION:-$VAR_AZURE_LOCATION}}"
           INFRA_TEMPLATE_REPO="${WD_INFRA_TEMPLATE:-$RD_INFRA_TEMPLATE}"
           INFRA_TEMPLATE_REF="${WD_INFRA_TEMPLATE_REF:-$RD_INFRA_TEMPLATE_REF}"
           APP_TEMPLATE_REPO="${WD_APP_TEMPLATE:-$RD_APP_TEMPLATE}"
@@ -154,15 +167,47 @@ jobs:
           MISSING=()
           [[ -z "$APP_NAME"               ]] && MISSING+=(app_name)
           [[ -z "$ENVIRONMENT"            ]] && MISSING+=(environment)
-          [[ -z "$AZURE_TENANT_ID"        ]] && MISSING+=(azure_tenant_id)
-          [[ -z "$AZURE_SUBSCRIPTION_ID"  ]] && MISSING+=(azure_subscription_id)
-          [[ -z "$AZURE_CLIENT_ID"        ]] && MISSING+=(azure_client_id)
-          [[ -z "$AZURE_LOCATION"         ]] && MISSING+=(azure_location)
           [[ -z "$INFRA_TEMPLATE_REPO"    ]] && MISSING+=(infra_template_repo)
           [[ -z "$CONTAINER_IMAGE"        ]] && MISSING+=(container_image)
           [[ -z "$CONTAINER_REGISTRY_URL" ]] && MISSING+=(container_registry_url)
-          if [[ ${#MISSING[@]} -gt 0 ]]; then
-            echo "::error::Missing required parameters: ${MISSING[*]}"
+
+          # Target-cloud parameters have TWO sources; when both are absent
+          # the report must name both, so they are tracked separately as
+          # "input_name|variable_name" pairs.
+          MISSING_CLOUD=()
+          [[ -z "$AZURE_TENANT_ID"       ]] && MISSING_CLOUD+=("azure_tenant_id|PROVISION_AZURE_TENANT_ID")
+          [[ -z "$AZURE_SUBSCRIPTION_ID" ]] && MISSING_CLOUD+=("azure_subscription_id|PROVISION_AZURE_SUBSCRIPTION_ID")
+          [[ -z "$AZURE_CLIENT_ID"       ]] && MISSING_CLOUD+=("azure_client_id|PROVISION_AZURE_CLIENT_ID")
+          [[ -z "$AZURE_LOCATION"        ]] && MISSING_CLOUD+=("azure_location|PROVISION_AZURE_LOCATION")
+
+          if [[ ${#MISSING[@]} -gt 0 || ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            [[ ${#MISSING[@]} -gt 0 ]] && echo "::error::Missing required parameters: ${MISSING[*]}"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+              if [[ ${#MISSING[@]} -gt 0 ]]; then
+                echo "## Missing required parameters"
+                echo ""
+                for M in "${MISSING[@]}"; do echo "- \`${M}\`"; done
+                echo ""
+              fi
+              if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+                echo "## Missing target-cloud parameters"
+                echo ""
+                echo "The target cloud is usually locked in for the organization: set each"
+                echo "repository variable once, or pass the input to override it per run."
+                echo "An input always overrides the variable."
+                echo ""
+                echo "| Parameter | Pass per run as | …or set once as repository variable |"
+                echo "|-----------|-----------------|--------------------------------------|"
+                for M in "${MISSING_CLOUD[@]}"; do
+                  IFS='|' read -r IN VAR <<<"$M"
+                  echo "| \`${IN}\` | workflow input / \`client_payload.${IN}\` | \`gh variable set ${VAR}\` |"
+                done
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -301,6 +301,13 @@ Flags fall back to upper-case env vars (`ENVIRONMENT`, `APP_NAME`, …) and the
 scripts auto-detect the platform repo from the current git remote. `--help`
 for the full reference.
 
+The target-cloud parameters (`--azure-tenant-id` / `--azure-subscription-id`
+/ `--azure-client-id` / `--azure-location`, and `--aws-region` /
+`--aws-role-arn`) are optional when the platform repository carries the
+`PROVISION_*` organization defaults — set once, per the *Lock in the target
+cloud* section of each setup guide. A flag always overrides the variable;
+with neither, the run fails fast naming both ways to supply the value.
+
 ### GitHub UI
 
 `Actions → <cloud> - Provision & Reconcile Application Resources → Run workflow`
@@ -311,7 +318,9 @@ Azure and AWS pipelines sit side by side in the Actions list.
 
 The `event_type` selects the cloud — for example,
 `azure-provision-infrastructure` in the case of Azure. The payload carries that
-cloud's identity and region parameters:
+cloud's identity and region parameters — or omits them, when the repository
+carries the `PROVISION_*` organization defaults (an explicit key always
+overrides the variable):
 
 ```bash
 curl -X POST \

--- a/docs/provision-aws.html
+++ b/docs/provision-aws.html
@@ -48,6 +48,10 @@
     section ul { margin: 8px 0; padding-left: 22px; }
     section li { margin: 4px 0; }
 
+    /* An author `display` rule (e.g. .grid-2) overrides the UA default for
+       the `hidden` attribute, so make hidden unconditionally win — the
+       target-cloud override section relies on it. */
+    [hidden] { display: none !important; }
     .grid-2 {
       display: grid;
       grid-template-columns: 1fr 1fr;
@@ -222,30 +226,48 @@
       <div class="grid-2">
 
         <div>
-          <label for="aws_region">AWS region <span class="req">*</span></label>
-          <input type="text" id="aws_region" name="aws_region" required
-                 placeholder="eu-west-1"
-                 pattern="^[a-z]{2}(-gov)?-[a-z]+-[0-9]$" />
-          <span class="hint">Region for the resources and the Terraform state bucket. No default — must be set explicitly.</span>
-          <div class="field-error" data-for="aws_region">Lowercase region code, e.g. <code>eu-west-1</code>.</div>
-        </div>
-
-        <div>
-          <label for="aws_role_arn">IAM role ARN <span class="req">*</span></label>
-          <input type="text" id="aws_role_arn" name="aws_role_arn" required
-                 placeholder="arn:aws:iam::123456789012:role/GitHubActionsRole"
-                 pattern="^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$" />
-          <span class="hint">Role assumed via OIDC. Its account ID also names the state bucket.</span>
-          <div class="field-error" data-for="aws_role_arn">Must be a full IAM role ARN, e.g. <code>arn:aws:iam::123456789012:role/GitHubActionsRole</code>.</div>
-        </div>
-
-        <div>
           <label for="main_domain">Root domain <span class="req">*</span></label>
           <input type="text" id="main_domain" name="main_domain" required
                  placeholder="example.com"
                  pattern="^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$" />
           <span class="hint">Existing Route 53 hosted zone in the same account. The certificate is issued for <code>&lt;app&gt;.&lt;env&gt;.&lt;domain&gt;</code>.</span>
           <div class="field-error" data-for="main_domain">Must be a domain name, e.g. <code>example.com</code>.</div>
+        </div>
+
+      </div>
+
+      <hr style="border: none; border-top: 1px solid var(--border); margin: 22px 0 18px;" />
+
+      <div>
+        <label style="display:flex; align-items:center; gap:8px;">
+          <input type="checkbox" id="override_cloud_params" style="width:auto; margin:0;" />
+          Override the organization's target-cloud defaults
+        </label>
+        <span class="hint">The workflow reads the target-cloud parameters from the
+          <code>PROVISION_AWS_*</code> repository variables set by the platform
+          operators. Tick to pass explicit values for this run — a value entered
+          here always overrides the variable; a field left empty keeps falling
+          back to it.</span>
+      </div>
+
+      <div class="grid-2" id="cloud-params" hidden>
+
+        <div>
+          <label for="aws_region">AWS region <span class="hint" style="display:inline;">(optional override)</span></label>
+          <input type="text" id="aws_region" name="aws_region"
+                 placeholder="eu-west-1"
+                 pattern="^[a-z]{2}(-gov)?-[a-z]+-[0-9]$" />
+          <span class="hint">Region for the resources and the Terraform state bucket. Empty ⇒ <code>PROVISION_AWS_REGION</code>.</span>
+          <div class="field-error" data-for="aws_region">Lowercase region code, e.g. <code>eu-west-1</code>.</div>
+        </div>
+
+        <div>
+          <label for="aws_role_arn">IAM role ARN <span class="hint" style="display:inline;">(optional override)</span></label>
+          <input type="text" id="aws_role_arn" name="aws_role_arn"
+                 placeholder="arn:aws:iam::123456789012:role/GitHubActionsRole"
+                 pattern="^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$" />
+          <span class="hint">Role assumed via OIDC. Its account ID also names the state bucket. Empty ⇒ <code>PROVISION_AWS_ROLE_ARN</code>.</span>
+          <div class="field-error" data-for="aws_role_arn">Must be a full IAM role ARN, e.g. <code>arn:aws:iam::123456789012:role/GitHubActionsRole</code>.</div>
         </div>
 
       </div>
@@ -383,6 +405,14 @@
     el.addEventListener('change', updateCurl);
   });
 
+  // ── Target-cloud override toggle ───────────────────────────────────────────
+  // Fields stay hidden (and out of the payload) unless the operator opts in.
+  const overrideCb  = document.getElementById('override_cloud_params');
+  const cloudParams = document.getElementById('cloud-params');
+  overrideCb.addEventListener('change', () => {
+    cloudParams.hidden = !overrideCb.checked;
+  });
+
   // ── Payload builder (omits empty optional fields) ──────────────────────────
   function buildPayload () {
     const v = id => (document.getElementById(id).value || '').trim();
@@ -391,14 +421,21 @@
       client_payload: {
         app_name: v('app_name'),
         environment: v('environment'),
-        aws_region: v('aws_region'),
-        aws_role_arn: v('aws_role_arn'),
         main_domain: v('main_domain'),
         infra_template_repo: v('infra_template_repo'),
         container_image: v('container_image'),
         container_registry_url: v('container_registry_url')
       }
     };
+    // Target-cloud parameters ride along ONLY when the override box is
+    // ticked, and only the non-empty ones: an omitted key lets the workflow
+    // fall back to the matching PROVISION_AWS_* repository variable, while
+    // an empty string would defeat that fallback.
+    if (document.getElementById('override_cloud_params').checked) {
+      ['aws_region', 'aws_role_arn'].forEach(id => {
+        if (v(id)) payload.client_payload[id] = v(id);
+      });
+    }
     ['infra_template_ref', 'app_template_repo', 'app_template_ref',
      'ci_workflow_file'].forEach(id => {
       if (v(id)) payload.client_payload[id] = v(id);

--- a/docs/provision-azure.html
+++ b/docs/provision-azure.html
@@ -48,6 +48,10 @@
     section ul { margin: 8px 0; padding-left: 22px; }
     section li { margin: 4px 0; }
 
+    /* An author `display` rule (e.g. .grid-2) overrides the UA default for
+       the `hidden` attribute, so make hidden unconditionally win — the
+       target-cloud override section relies on it. */
+    [hidden] { display: none !important; }
     .grid-2 {
       display: grid;
       grid-template-columns: 1fr 1fr;
@@ -217,41 +221,53 @@
 
       <hr style="border: none; border-top: 1px solid var(--border); margin: 22px 0 18px;" />
 
-      <div class="grid-2">
+      <div>
+        <label style="display:flex; align-items:center; gap:8px;">
+          <input type="checkbox" id="override_cloud_params" style="width:auto; margin:0;" />
+          Override the organization's target-cloud defaults
+        </label>
+        <span class="hint">The workflow reads the target-cloud parameters from the
+          <code>PROVISION_AZURE_*</code> repository variables set by the platform
+          operators. Tick to pass explicit values for this run — a value entered
+          here always overrides the variable; a field left empty keeps falling
+          back to it.</span>
+      </div>
+
+      <div class="grid-2" id="cloud-params" hidden>
 
         <div>
-          <label for="azure_tenant_id">Azure Tenant ID <span class="req">*</span></label>
-          <input type="text" id="azure_tenant_id" name="azure_tenant_id" required
+          <label for="azure_tenant_id">Azure Tenant ID <span class="hint" style="display:inline;">(optional override)</span></label>
+          <input type="text" id="azure_tenant_id" name="azure_tenant_id"
                  placeholder="11111111-1111-1111-1111-111111111111"
                  pattern="^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" />
-          <span class="hint">Entra tenant GUID.</span>
+          <span class="hint">Entra tenant GUID. Empty ⇒ <code>PROVISION_AZURE_TENANT_ID</code>.</span>
           <div class="field-error" data-for="azure_tenant_id">Must be a GUID.</div>
         </div>
 
         <div>
-          <label for="azure_subscription_id">Azure Subscription ID <span class="req">*</span></label>
-          <input type="text" id="azure_subscription_id" name="azure_subscription_id" required
+          <label for="azure_subscription_id">Azure Subscription ID <span class="hint" style="display:inline;">(optional override)</span></label>
+          <input type="text" id="azure_subscription_id" name="azure_subscription_id"
                  placeholder="00000000-0000-0000-0000-000000000000"
                  pattern="^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" />
-          <span class="hint">GUID, 8-4-4-4-12 hex.</span>
+          <span class="hint">GUID, 8-4-4-4-12 hex. Empty ⇒ <code>PROVISION_AZURE_SUBSCRIPTION_ID</code>.</span>
           <div class="field-error" data-for="azure_subscription_id">Must be a GUID.</div>
         </div>
 
         <div>
-          <label for="azure_client_id">Azure Client ID (SP) <span class="req">*</span></label>
-          <input type="text" id="azure_client_id" name="azure_client_id" required
+          <label for="azure_client_id">Azure Client ID (SP) <span class="hint" style="display:inline;">(optional override)</span></label>
+          <input type="text" id="azure_client_id" name="azure_client_id"
                  placeholder="00000000-0000-0000-0000-000000000000"
                  pattern="^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" />
-          <span class="hint">Application (client) ID of the platform service principal.</span>
+          <span class="hint">Application (client) ID of the platform service principal. Empty ⇒ <code>PROVISION_AZURE_CLIENT_ID</code>.</span>
           <div class="field-error" data-for="azure_client_id">Must be a GUID.</div>
         </div>
 
         <div>
-          <label for="azure_location">Azure region <span class="req">*</span></label>
-          <input type="text" id="azure_location" name="azure_location" required
+          <label for="azure_location">Azure region <span class="hint" style="display:inline;">(optional override)</span></label>
+          <input type="text" id="azure_location" name="azure_location"
                  placeholder="westeurope"
                  pattern="^[a-z][a-z0-9]+$" />
-          <span class="hint">Region for the Terraform state storage account. No default — must be set explicitly.</span>
+          <span class="hint">Region for all resources and the state storage account. Empty ⇒ <code>PROVISION_AZURE_LOCATION</code>.</span>
           <div class="field-error" data-for="azure_location">Lowercase letters and digits, e.g. <code>westeurope</code>.</div>
         </div>
 
@@ -390,6 +406,14 @@
     el.addEventListener('change', updateCurl);
   });
 
+  // ── Target-cloud override toggle ───────────────────────────────────────────
+  // Fields stay hidden (and out of the payload) unless the operator opts in.
+  const overrideCb  = document.getElementById('override_cloud_params');
+  const cloudParams = document.getElementById('cloud-params');
+  overrideCb.addEventListener('change', () => {
+    cloudParams.hidden = !overrideCb.checked;
+  });
+
   // ── Payload builder (omits empty optional fields) ──────────────────────────
   function buildPayload () {
     const v = id => (document.getElementById(id).value || '').trim();
@@ -398,15 +422,21 @@
       client_payload: {
         app_name: v('app_name'),
         environment: v('environment'),
-        azure_tenant_id: v('azure_tenant_id'),
-        azure_subscription_id: v('azure_subscription_id'),
-        azure_client_id: v('azure_client_id'),
-        azure_location: v('azure_location'),
         infra_template_repo: v('infra_template_repo'),
         container_image: v('container_image'),
         container_registry_url: v('container_registry_url')
       }
     };
+    // Target-cloud parameters ride along ONLY when the override box is
+    // ticked, and only the non-empty ones: an omitted key lets the workflow
+    // fall back to the matching PROVISION_AZURE_* repository variable,
+    // while an empty string would defeat that fallback.
+    if (document.getElementById('override_cloud_params').checked) {
+      ['azure_tenant_id', 'azure_subscription_id', 'azure_client_id',
+       'azure_location'].forEach(id => {
+        if (v(id)) payload.client_payload[id] = v(id);
+      });
+    }
     ['infra_template_ref', 'app_template_repo', 'app_template_ref',
      'ci_workflow_file'].forEach(id => {
       if (v(id)) payload.client_payload[id] = v(id);

--- a/docs/setup-aws.md
+++ b/docs/setup-aws.md
@@ -288,8 +288,8 @@ Resources → Run workflow**, and provide:
 | ----- | -------- | ------------------------ |
 | `app_name` | yes | `test-webapp` (3–22 chars, lowercase, digits, hyphens) |
 | `environment` | yes | `dev` — promotion order is enforced: `staging` can only be requested once `dev` is provisioned, `prod` once `dev` and `staging` both are ready (requesting `all`, or reconciling an environment that already exists, always passes) |
-| `aws_region` | yes | `eu-west-1` — region for the tfstate bucket and every provisioned resource. No default, by design: an implicit region silently deploys to the wrong place |
-| `aws_role_arn` | yes | the role ARN captured in step 2 |
+| `aws_region` | no* | `eu-west-1` — region for the tfstate bucket and every provisioned resource; falls back to the `PROVISION_AWS_REGION` repository variable. There is deliberately no built-in default: an implicit region silently deploys to the wrong place |
+| `aws_role_arn` | no* | the role ARN captured in step 2 — falls back to `PROVISION_AWS_ROLE_ARN` |
 | `main_domain` | yes | the root domain of your Route 53 public hosted zone (e.g. `example.com`) — drives the ACM certificate and DNS records for `<app>.<env>.<domain>` |
 | `infra_template_repo` | yes | the `<owner>/<name>` of the infrastructure template repo |
 | `infra_template_ref` | no | _(leave empty — uses the template's default branch)_ git ref (tag, branch, or commit SHA) to pin the infra template |
@@ -300,8 +300,26 @@ Resources → Run workflow**, and provide:
 | `ci_workflow_file` | no | _(leave empty — defaults to `ci.yml`; only used when `app_template_repo` is set)_ |
 
 > **Reconcile caveat.** `container_image` only matters on the first apply —
-> afterwards the ECS service's `lifecycle.ignore_changes` keeps whatever
-> CodeDeploy deployed.
+> afterwards CI/CD workflows own the deployed container image.
+
+\* **no\*** = optional *per run*, but a value must come from somewhere: the
+input always overrides the repository variable, and when neither is present
+the run fails fast naming both ways to supply it. See *Lock in the target
+cloud* below.
+
+### Lock in the target cloud (recommended)
+
+In most organizations the target cloud is locked in, so passing the same
+identity parameters on every request is boilerplate. Set them once as
+repository variables and every form/CLI/API request can omit them:
+
+```bash
+gh variable set PROVISION_AWS_REGION   -R <org>/<platform-repo> --body "eu-west-1"
+gh variable set PROVISION_AWS_ROLE_ARN -R <org>/<platform-repo> --body "arn:aws:iam::<account-id>:role/GitHubActionsPlatformEng"
+```
+
+A per-run input always overrides the variable (the provisioning form hides
+these fields behind an "override the organization's defaults" checkbox).
 
 ### What you should observe
 

--- a/docs/setup-azure.md
+++ b/docs/setup-azure.md
@@ -393,10 +393,10 @@ Resources → Run workflow**, and provide:
 | ----- | -------- | ------------------------ |
 | `app_name` | yes | `test-webapp` (3–22 chars, lowercase, digits, hyphens) |
 | `environment` | yes | `dev` — promotion order is enforced: `staging` can only be requested once `dev` is provisioned, `prod` once `dev` and `staging` both are ready (requesting `all`, or reconciling an environment that already exists, always passes) |
-| `azure_tenant_id` | yes | the tenant GUID captured in step 1 |
-| `azure_subscription_id` | yes | the GUID captured in step 1 |
-| `azure_client_id` | yes | the `appId` captured in step 1 |
-| `location` | yes | `westeurope` — Azure region for the tfstate storage account and every provisioned resource. No default, by design: an implicit region silently deploys to the wrong place |
+| `azure_tenant_id` | no* | the tenant GUID captured in step 1 — falls back to the `PROVISION_AZURE_TENANT_ID` repository variable |
+| `azure_subscription_id` | no* | the GUID captured in step 1 — falls back to `PROVISION_AZURE_SUBSCRIPTION_ID` |
+| `azure_client_id` | no* | the `appId` captured in step 1 — falls back to `PROVISION_AZURE_CLIENT_ID` |
+| `azure_location` | no* | `westeurope` — Azure region for the tfstate storage account and every provisioned resource; falls back to `PROVISION_AZURE_LOCATION`. There is deliberately no built-in default: an implicit region silently deploys to the wrong place |
 | `infra_template_repo` | yes | the `<owner>/<name>` of the infrastructure template repo |
 | `infra_template_ref` | no | _(leave empty — uses the template's default branch)_ git ref (tag, branch, or commit SHA) to pin the infra template |
 | `app_template_repo` | no | the `<owner>/<name>` of the application template repo; **leave empty to skip the app-repo phase** (infra-only run) |
@@ -404,6 +404,30 @@ Resources → Run workflow**, and provide:
 | `container_image` | yes | image reference **without** the registry host, e.g. `deors/template-helloworld-express:sha-af53b68`. The archetype fixes the container contract — port 8080, health endpoint `/health`; the image must follow it |
 | `container_registry_url` | yes | the registry host |
 | `ci_workflow_file` | no | _(leave empty — defaults to `ci.yml`; only used when `app_template_repo` is set)_ |
+
+> **Reconcile caveat.** `container_image` only matters on the first apply —
+> afterwards CI/CD workflows own the deployed container image.
+
+\* **no\*** = optional *per run*, but a value must come from somewhere: the
+input always overrides the repository variable, and when neither is present
+the run fails fast naming both ways to supply it. See *Lock in the target
+cloud* below.
+
+### Lock in the target cloud (recommended)
+
+In most organizations the target cloud is locked in, so passing the same
+identity parameters on every request is boilerplate. Set them once as
+repository variables and every form/CLI/API request can omit them:
+
+```bash
+gh variable set PROVISION_AZURE_TENANT_ID       -R <org>/<platform-repo> --body "<tenant-guid>"
+gh variable set PROVISION_AZURE_SUBSCRIPTION_ID -R <org>/<platform-repo> --body "<subscription-guid>"
+gh variable set PROVISION_AZURE_CLIENT_ID       -R <org>/<platform-repo> --body "<client-guid>"
+gh variable set PROVISION_AZURE_LOCATION        -R <org>/<platform-repo> --body "westeurope"
+```
+
+A per-run input always overrides the variable (the provisioning form hides
+these fields behind an "override the organization's defaults" checkbox).
 
 ### What you should observe
 

--- a/scripts/trigger-provision-aws.sh
+++ b/scripts/trigger-provision-aws.sh
@@ -25,8 +25,6 @@ Usage:
 Required (flag OR env var):
   --app-name            <name>                    APP_NAME
   --environment         <dev|staging|prod|all>    ENVIRONMENT
-  --aws-region          <region>                  AWS_REGION
-  --aws-role-arn        <arn>                     AWS_ROLE_ARN
   --main-domain         <domain>                  MAIN_DOMAIN
   --infra-template-repo <owner/name>              INFRA_TEMPLATE_REPO
   --container-image     <ref>                     CONTAINER_IMAGE
@@ -36,6 +34,12 @@ Required (flag OR env var):
                                                      reconcile runs)
 
 Optional:
+  --aws-region             <region>      AWS_REGION
+                                           (falls back to the PROVISION_AWS_REGION
+                                            repository variable — the organization
+                                            default; a flag always overrides it)
+  --aws-role-arn           <arn>         AWS_ROLE_ARN
+                                           (falls back to PROVISION_AWS_ROLE_ARN)
   --app-template-repo      <owner/name>  APP_TEMPLATE_REPO
                                            (default: empty — provisions
                                             infrastructure only, no app repo)
@@ -110,8 +114,6 @@ done
 MISSING=()
 [[ -z "$APP_NAME"            ]] && MISSING+=("--app-name / APP_NAME")
 [[ -z "$ENVIRONMENT"         ]] && MISSING+=("--environment / ENVIRONMENT")
-[[ -z "$AWS_REGION"          ]] && MISSING+=("--aws-region / AWS_REGION")
-[[ -z "$AWS_ROLE_ARN"        ]] && MISSING+=("--aws-role-arn / AWS_ROLE_ARN")
 [[ -z "$MAIN_DOMAIN"         ]] && MISSING+=("--main-domain / MAIN_DOMAIN")
 [[ -z "$INFRA_TEMPLATE_REPO" ]] && MISSING+=("--infra-template-repo / INFRA_TEMPLATE_REPO")
 [[ -z "$CONTAINER_IMAGE"     ]] && MISSING+=("--container-image / CONTAINER_IMAGE")
@@ -136,7 +138,7 @@ esac
 # The workflow parses this ARN for both the account ID (which names the tfstate
 # bucket) and the role name (whose trust policy gains the app's OIDC subject),
 # so a malformed value silently targets the wrong thing rather than erroring.
-if ! [[ "$AWS_ROLE_ARN" =~ ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$ ]]; then
+if [[ -n "$AWS_ROLE_ARN" ]] && ! [[ "$AWS_ROLE_ARN" =~ ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$ ]]; then
   INVALID+=("aws_role_arn must be a full IAM role ARN, e.g. arn:aws:iam::123456789012:role/GitHubActionsRole — got '${AWS_ROLE_ARN}'")
 fi
 if [[ ${#INVALID[@]} -gt 0 ]]; then
@@ -179,12 +181,12 @@ PAYLOAD=$(jq -nc \
     client_payload: ({
       app_name:            $app,
       environment:         $env,
-      aws_region:          $region,
-      aws_role_arn:        $role,
       main_domain:         $domain,
       infra_template_repo: $infra_tmpl,
       container_image:     $image
     }
+    + (if $region    != "" then {aws_region:             $region}    else {} end)
+    + (if $role      != "" then {aws_role_arn:           $role}      else {} end)
     + (if $infra_ref != "" then {infra_template_ref:     $infra_ref} else {} end)
     + (if $app_tmpl  != "" then {app_template_repo:      $app_tmpl}  else {} end)
     + (if $app_ref   != "" then {app_template_ref:       $app_ref}   else {} end)

--- a/scripts/trigger-provision-azure.sh
+++ b/scripts/trigger-provision-azure.sh
@@ -20,10 +20,6 @@ Usage:
 Required (flag OR env var):
   --app-name              <name>                    APP_NAME
   --environment           <dev|staging|prod|all>    ENVIRONMENT
-  --azure-tenant-id       <guid>                    AZURE_TENANT_ID
-  --azure-subscription-id <guid>                    AZURE_SUBSCRIPTION_ID
-  --azure-client-id       <guid>                    AZURE_CLIENT_ID
-  --azure-location        <region>                  AZURE_LOCATION
   --infra-template-repo   <owner/name>              INFRA_TEMPLATE_REPO
   --container-image       <ref>                     CONTAINER_IMAGE
                                                       (e.g. deors/template-helloworld-express:sha-af53b68,
@@ -32,6 +28,16 @@ Required (flag OR env var):
                                                        reconcile runs)
 
 Optional:
+  --azure-tenant-id        <guid>        AZURE_TENANT_ID
+                                            (falls back to the PROVISION_AZURE_TENANT_ID
+                                             repository variable — the organization
+                                             default; a flag always overrides it)
+  --azure-subscription-id  <guid>        AZURE_SUBSCRIPTION_ID
+                                            (falls back to PROVISION_AZURE_SUBSCRIPTION_ID)
+  --azure-client-id        <guid>        AZURE_CLIENT_ID
+                                            (falls back to PROVISION_AZURE_CLIENT_ID)
+  --azure-location         <region>      AZURE_LOCATION
+                                            (falls back to PROVISION_AZURE_LOCATION)
   --app-template-repo      <owner/name>  APP_TEMPLATE_REPO
                                             (default: empty — provisions
                                              infrastructure only, no app repo)
@@ -109,10 +115,6 @@ done
 MISSING=()
 [[ -z "$APP_NAME"              ]] && MISSING+=("--app-name / APP_NAME")
 [[ -z "$ENVIRONMENT"           ]] && MISSING+=("--environment / ENVIRONMENT")
-[[ -z "$AZURE_TENANT_ID"       ]] && MISSING+=("--azure-tenant-id / AZURE_TENANT_ID")
-[[ -z "$AZURE_SUBSCRIPTION_ID" ]] && MISSING+=("--azure-subscription-id / AZURE_SUBSCRIPTION_ID")
-[[ -z "$AZURE_CLIENT_ID"       ]] && MISSING+=("--azure-client-id / AZURE_CLIENT_ID")
-[[ -z "$AZURE_LOCATION"        ]] && MISSING+=("--azure-location / AZURE_LOCATION")
 [[ -z "$INFRA_TEMPLATE_REPO"   ]] && MISSING+=("--infra-template-repo / INFRA_TEMPLATE_REPO")
 [[ -z "$CONTAINER_IMAGE"       ]] && MISSING+=("--container-image / CONTAINER_IMAGE")
 
@@ -159,13 +161,13 @@ PAYLOAD=$(jq -nc \
     client_payload: ({
       app_name:              $app,
       environment:           $env,
-      azure_tenant_id:       $tid,
-      azure_subscription_id: $sub,
-      azure_client_id:       $cid,
-      azure_location:        $loc,
       infra_template_repo:   $infra_tmpl,
       container_image:       $image
     }
+    + (if $tid       != "" then {azure_tenant_id:        $tid}       else {} end)
+    + (if $sub       != "" then {azure_subscription_id:  $sub}       else {} end)
+    + (if $cid       != "" then {azure_client_id:        $cid}       else {} end)
+    + (if $loc       != "" then {azure_location:         $loc}       else {} end)
     + (if $infra_ref != "" then {infra_template_ref:     $infra_ref} else {} end)
     + (if $app_tmpl  != "" then {app_template_repo:      $app_tmpl}  else {} end)
     + (if $app_ref   != "" then {app_template_ref:       $app_ref}   else {} end)


### PR DESCRIPTION
Implements **P19** (#59): the target cloud is usually locked in for the organization, so its identity parameters stop being per-request boilerplate.

## Workflows (Azure + AWS)

- `azure_tenant_id` / `azure_subscription_id` / `azure_client_id` / `azure_location` and `aws_region` / `aws_role_arn` are now **optional inputs with no default**.
- Each falls back to a `PROVISION_*` repository variable (`PROVISION_AZURE_TENANT_ID`, …, `PROVISION_AWS_REGION`, `PROVISION_AWS_ROLE_ARN`) — the organization default, set once.
- Precedence per parameter: workflow_dispatch input / `client_payload` key **always overrides** the variable.
- Neither present ⇒ `resolve-inputs` fails fast with one `::error::` per missing parameter naming **both** ways to supply it, plus a job-summary table carrying the exact `gh variable set` commands.
- `main_domain` deliberately stays an explicit input (DNS/app concern, not cloud identity).

## Forms

- The cloud parameter fields start **hidden** and are revealed by an "Override the organization's target-cloud defaults" checkbox.
- Unchecked ⇒ the payload omits the keys entirely (an empty string would defeat the workflow-side fallback); checked ⇒ only non-empty fields are sent, so partial overrides work per parameter.
- Includes a `[hidden] { display: none !important; }` rule: the author-level `.grid-2` display rule would otherwise override the `hidden` attribute and leave the section visible.

## Scripts + docs

- `trigger-provision-{azure,aws}.sh`: cloud flags optional, omitted from the payload when not given, format validation only when a value is provided.
- Setup guides: new *Lock in the target cloud* sections with the `gh variable set` one-liners; input tables updated with a `no*` marker (optional per run, a value must still come from somewhere). index.md CLI/API notes updated.

## Verification

- Resolution precedence simulated for every parameter on both clouds: variable-only, input-over-variable, payload-over-variable, and neither (per-parameter errors + summary table).
- Forms exercised in a browser against computed styles: hidden initially, toggled by the checkbox, payload keys present exactly when checked and non-empty.
- Both workflows pass the YAML parser; both scripts pass `bash -n` and produce the expected payload key sets.

Note for the first run after merging: no `PROVISION_*` variables exist yet in this repository, so a request without explicit cloud parameters will fail with the new guidance until they are set (or the override is used).

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)