### PR TITLE
feat: extend PROVISION_* cloud defaults to the delete, verify and tag…

### DIFF
--- a/.github/workflows/delete-app-resources-all-aws.yml
+++ b/.github/workflows/delete-app-resources-all-aws.yml
@@ -19,13 +19,13 @@ on:
         type: string
         required: true
       aws_region:
-        description: AWS region holding the resources and the tfstate bucket (e.g. eu-west-1)
+        description: "AWS region holding the resources and the tfstate bucket (e.g. eu-west-1) (optional — falls back to the PROVISION_AWS_REGION repository variable)"
         type: string
-        required: true
+        required: false
       aws_role_arn:
-        description: ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole)
+        description: "ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole) (optional — falls back to the PROVISION_AWS_ROLE_ARN repository variable)"
         type: string
-        required: true
+        required: false
       main_domain:
         description: "Root domain the template issued certificates under (leave empty when HTTPS was not enabled)"
         type: string
@@ -53,6 +53,8 @@ jobs:
     outputs:
       app_name:       ${{ steps.validate.outputs.app_name }}
       delete_tfstate: ${{ steps.validate.outputs.delete_tfstate }}
+      aws_region:     ${{ steps.validate.outputs.aws_region }}
+      aws_role_arn:   ${{ steps.validate.outputs.aws_role_arn }}
     steps:
       - name: Validate inputs
         id: validate
@@ -60,8 +62,43 @@ jobs:
           APP_NAME:              ${{ github.event.inputs.app_name }}
           CONFIRMATION_APP_NAME: ${{ github.event.inputs.confirmation_app_name }}
           DELETE_TFSTATE:        ${{ github.event.inputs.delete_tfstate }}
+          WD_REGION:             ${{ needs.validate.outputs.aws_region }}
+          WD_ROLE_ARN:           ${{ needs.validate.outputs.aws_role_arn }}
+          VAR_REGION:            ${{ vars.PROVISION_AWS_REGION }}
+          VAR_ROLE_ARN:          ${{ vars.PROVISION_AWS_ROLE_ARN }}
         run: |
           set -euo pipefail
+
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback
+          # (this workflow is dispatch-only, the external interface).
+          AWS_REGION="${WD_REGION:-$VAR_REGION}"
+          AWS_ROLE_ARN="${WD_ROLE_ARN:-$VAR_ROLE_ARN}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AWS_REGION"   ]] && MISSING_CLOUD+=("aws_region|PROVISION_AWS_REGION")
+          [[ -z "$AWS_ROLE_ARN" ]] && MISSING_CLOUD+=("aws_role_arn|PROVISION_AWS_ROLE_ARN")
+          if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+            echo "## Missing target-cloud parameters"
+            echo ""
+            echo "The target cloud is usually locked in for the organization: set each"
+            echo "repository variable once, or pass the input to override it per run."
+            echo "An input always overrides the variable."
+            echo ""
+            echo "| Parameter | Pass per run as | …or set once as repository variable |"
+            echo "|-----------|-----------------|--------------------------------------|"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "| \`${IN}\` | workflow input | \`gh variable set ${VAR}\` |"
+            done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
           [[ -z "$APP_NAME" ]] && { echo "::error::app_name is required"; exit 1; }
           if [[ "$APP_NAME" != "$CONFIRMATION_APP_NAME" ]]; then
@@ -79,6 +116,8 @@ jobs:
 
           echo "app_name=$APP_NAME"             >> "$GITHUB_OUTPUT"
           echo "delete_tfstate=$DELETE_TFSTATE" >> "$GITHUB_OUTPUT"
+          echo "aws_region=$AWS_REGION"         >> "$GITHUB_OUTPUT"
+          echo "aws_role_arn=$AWS_ROLE_ARN"     >> "$GITHUB_OUTPUT"
 
   # One environment at a time (max-parallel: 1). Serialising is not just
   # tidiness: the environments share an IAM role whose trust policy is edited
@@ -97,8 +136,8 @@ jobs:
       environment:              ${{ matrix.environment }}
       confirmation_app_name:    ${{ needs.validate.outputs.app_name }}
       confirmation_environment: ${{ matrix.environment }}
-      aws_region:               ${{ github.event.inputs.aws_region }}
-      aws_role_arn:             ${{ github.event.inputs.aws_role_arn }}
+      aws_region:               ${{ needs.validate.outputs.aws_region }}
+      aws_role_arn:             ${{ needs.validate.outputs.aws_role_arn }}
       main_domain:              ${{ github.event.inputs.main_domain }}
     secrets: inherit
 
@@ -117,14 +156,14 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ github.event.inputs.aws_role_arn }}
-          aws-region:     ${{ github.event.inputs.aws_region }}
+          role-to-assume: ${{ needs.validate.outputs.aws_role_arn }}
+          aws-region:     ${{ needs.validate.outputs.aws_region }}
 
       - name: Empty and delete state bucket
         id: delete_bucket
         env:
           APP_NAME:   ${{ needs.validate.outputs.app_name }}
-          AWS_REGION: ${{ github.event.inputs.aws_region }}
+          AWS_REGION: ${{ needs.validate.outputs.aws_region }}
         run: |
           set -euo pipefail
 
@@ -186,8 +225,8 @@ jobs:
     uses: ./.github/workflows/delete-resource-group-aws.yml
     with:
       resource_group_name: rg-${{ needs.validate.outputs.app_name }}-tfstate
-      aws_region:          ${{ github.event.inputs.aws_region }}
-      aws_role_arn:        ${{ github.event.inputs.aws_role_arn }}
+      aws_region:          ${{ needs.validate.outputs.aws_region }}
+      aws_role_arn:        ${{ needs.validate.outputs.aws_role_arn }}
 
   summary:
     name: Summary

--- a/.github/workflows/delete-app-resources-all.yml
+++ b/.github/workflows/delete-app-resources-all.yml
@@ -19,17 +19,17 @@ on:
         type: string
         required: true
       azure_tenant_id:
-        description: Azure Tenant ID
+        description: "Azure Tenant ID (optional — falls back to the PROVISION_AZURE_TENANT_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_subscription_id:
-        description: Azure Subscription ID
+        description: "Azure Subscription ID (optional — falls back to the PROVISION_AZURE_SUBSCRIPTION_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_client_id:
-        description: Client ID of the Azure service principal / managed identity used for OIDC login
+        description: "Client ID of the Azure service principal / managed identity used for OIDC login (optional — falls back to the PROVISION_AZURE_CLIENT_ID repository variable)"
         type: string
-        required: true
+        required: false
       confirmation_app_name:
         description: Repeat the exact application name to confirm destructive deletion
         type: string
@@ -59,6 +59,9 @@ jobs:
       app_name:            ${{ steps.validate.outputs.app_name }}
       delete_tfstate:      ${{ steps.validate.outputs.delete_tfstate }}
       wait_for_completion: ${{ steps.validate.outputs.wait_for_completion }}
+      azure_tenant_id:       ${{ steps.validate.outputs.azure_tenant_id }}
+      azure_subscription_id: ${{ steps.validate.outputs.azure_subscription_id }}
+      azure_client_id:       ${{ steps.validate.outputs.azure_client_id }}
     steps:
       - name: Validate inputs
         id: validate
@@ -67,8 +70,47 @@ jobs:
           CONFIRMATION_APP_NAME: ${{ github.event.inputs.confirmation_app_name }}
           DELETE_TFSTATE:        ${{ github.event.inputs.delete_tfstate }}
           WAIT_FOR_COMPLETION:   ${{ github.event.inputs.wait_for_completion }}
+          WD_TENANT_ID:          ${{ needs.validate.outputs.azure_tenant_id }}
+          WD_SUB_ID:             ${{ needs.validate.outputs.azure_subscription_id }}
+          WD_CLIENT_ID:          ${{ needs.validate.outputs.azure_client_id }}
+          VAR_TENANT_ID:         ${{ vars.PROVISION_AZURE_TENANT_ID }}
+          VAR_SUB_ID:            ${{ vars.PROVISION_AZURE_SUBSCRIPTION_ID }}
+          VAR_CLIENT_ID:         ${{ vars.PROVISION_AZURE_CLIENT_ID }}
         run: |
           set -euo pipefail
+
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback
+          # (this workflow is dispatch-only, the external interface).
+          AZURE_TENANT_ID="${WD_TENANT_ID:-$VAR_TENANT_ID}"
+          AZURE_SUBSCRIPTION_ID="${WD_SUB_ID:-$VAR_SUB_ID}"
+          AZURE_CLIENT_ID="${WD_CLIENT_ID:-$VAR_CLIENT_ID}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AZURE_TENANT_ID"       ]] && MISSING_CLOUD+=("azure_tenant_id|PROVISION_AZURE_TENANT_ID")
+          [[ -z "$AZURE_SUBSCRIPTION_ID" ]] && MISSING_CLOUD+=("azure_subscription_id|PROVISION_AZURE_SUBSCRIPTION_ID")
+          [[ -z "$AZURE_CLIENT_ID"       ]] && MISSING_CLOUD+=("azure_client_id|PROVISION_AZURE_CLIENT_ID")
+          if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+            echo "## Missing target-cloud parameters"
+            echo ""
+            echo "The target cloud is usually locked in for the organization: set each"
+            echo "repository variable once, or pass the input to override it per run."
+            echo "An input always overrides the variable."
+            echo ""
+            echo "| Parameter | Pass per run as | …or set once as repository variable |"
+            echo "|-----------|-----------------|--------------------------------------|"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "| \`${IN}\` | workflow input | \`gh variable set ${VAR}\` |"
+            done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
           [[ -z "$APP_NAME" ]] && { echo "::error::app_name is required"; exit 1; }
           if [[ "$APP_NAME" != "$CONFIRMATION_APP_NAME" ]]; then
@@ -91,6 +133,9 @@ jobs:
           echo "app_name=$APP_NAME"                       >> "$GITHUB_OUTPUT"
           echo "delete_tfstate=$DELETE_TFSTATE"           >> "$GITHUB_OUTPUT"
           echo "wait_for_completion=$WAIT_FOR_COMPLETION" >> "$GITHUB_OUTPUT"
+          echo "azure_tenant_id=$AZURE_TENANT_ID"         >> "$GITHUB_OUTPUT"
+          echo "azure_subscription_id=$AZURE_SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
+          echo "azure_client_id=$AZURE_CLIENT_ID"         >> "$GITHUB_OUTPUT"
 
   # One environment at a time (max-parallel: 1). Serialising is not just
   # tidiness: the environments share the platform App Registration whose
@@ -110,9 +155,9 @@ jobs:
       environment:               ${{ matrix.environment }}
       confirmation_app_name:     ${{ needs.validate.outputs.app_name }}
       confirmation_environment:  ${{ matrix.environment }}
-      azure_tenant_id:           ${{ github.event.inputs.azure_tenant_id }}
-      azure_subscription_id:     ${{ github.event.inputs.azure_subscription_id }}
-      azure_client_id:           ${{ github.event.inputs.azure_client_id }}
+      azure_tenant_id:           ${{ needs.validate.outputs.azure_tenant_id }}
+      azure_subscription_id:     ${{ needs.validate.outputs.azure_subscription_id }}
+      azure_client_id:           ${{ needs.validate.outputs.azure_client_id }}
       wait_for_completion:       ${{ needs.validate.outputs.wait_for_completion }}
     secrets: inherit
 
@@ -127,9 +172,9 @@ jobs:
     uses: ./.github/workflows/delete-resource-group.yml
     with:
       resource_group_name:   rg-${{ needs.validate.outputs.app_name }}-tfstate
-      azure_tenant_id:       ${{ github.event.inputs.azure_tenant_id }}
-      azure_subscription_id: ${{ github.event.inputs.azure_subscription_id }}
-      azure_client_id:       ${{ github.event.inputs.azure_client_id }}
+      azure_tenant_id:       ${{ needs.validate.outputs.azure_tenant_id }}
+      azure_subscription_id: ${{ needs.validate.outputs.azure_subscription_id }}
+      azure_client_id:       ${{ needs.validate.outputs.azure_client_id }}
       wait_for_completion:   ${{ needs.validate.outputs.wait_for_completion }}
 
   summary:

--- a/.github/workflows/delete-app-resources-single-aws.yml
+++ b/.github/workflows/delete-app-resources-single-aws.yml
@@ -72,13 +72,13 @@ on:
         options: [dev, staging, prod]
         required: true
       aws_region:
-        description: AWS region holding the resources (e.g. eu-west-1)
+        description: "AWS region holding the resources (e.g. eu-west-1) (optional — falls back to the PROVISION_AWS_REGION repository variable)"
         type: string
-        required: true
+        required: false
       aws_role_arn:
-        description: ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole)
+        description: "ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole) (optional — falls back to the PROVISION_AWS_ROLE_ARN repository variable)"
         type: string
-        required: true
+        required: false
       main_domain:
         description: "Root domain the template issued certificates under (leave empty when HTTPS was not enabled)"
         type: string
@@ -107,6 +107,8 @@ jobs:
       resource_group_name: ${{ steps.out.outputs.resource_group_name }}
       app_repo_full:       ${{ steps.out.outputs.app_repo_full }}
       infra_repo_full:     ${{ steps.out.outputs.infra_repo_full }}
+      aws_region:          ${{ steps.out.outputs.aws_region }}
+      aws_role_arn:        ${{ steps.out.outputs.aws_role_arn }}
     steps:
       - name: Validate
         id: out
@@ -119,6 +121,12 @@ jobs:
           WD_CONFIRM_APP: ${{ github.event.inputs.confirmation_app_name }}
           IN_CONFIRM_ENV: ${{ inputs.confirmation_environment }}
           WD_CONFIRM_ENV: ${{ github.event.inputs.confirmation_environment }}
+          IN_REGION:      ${{ inputs.aws_region }}
+          WD_REGION:      ${{ github.event.inputs.aws_region }}
+          IN_ROLE_ARN:    ${{ inputs.aws_role_arn }}
+          WD_ROLE_ARN:    ${{ github.event.inputs.aws_role_arn }}
+          VAR_REGION:     ${{ vars.PROVISION_AWS_REGION }}
+          VAR_ROLE_ARN:   ${{ vars.PROVISION_AWS_ROLE_ARN }}
         run: |
           set -euo pipefail
 
@@ -126,6 +134,39 @@ jobs:
           ENVIRONMENT="${IN_ENV:-$WD_ENV}"
           CONFIRM_APP_NAME="${IN_CONFIRM_APP:-$WD_CONFIRM_APP}"
           CONFIRM_ENVIRONMENT="${IN_CONFIRM_ENV:-$WD_CONFIRM_ENV}"
+
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback. It
+          # only engages on the external interface (workflow_dispatch /
+          # repository_dispatch): workflow_call inputs stay required, so
+          # workflow-to-workflow calls always pass explicit values.
+          AWS_REGION="${IN_REGION:-${WD_REGION:-$VAR_REGION}}"
+          AWS_ROLE_ARN="${IN_ROLE_ARN:-${WD_ROLE_ARN:-$VAR_ROLE_ARN}}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AWS_REGION"   ]] && MISSING_CLOUD+=("aws_region|PROVISION_AWS_REGION")
+          [[ -z "$AWS_ROLE_ARN" ]] && MISSING_CLOUD+=("aws_role_arn|PROVISION_AWS_ROLE_ARN")
+          if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+            echo "## Missing target-cloud parameters"
+            echo ""
+            echo "The target cloud is usually locked in for the organization: set each"
+            echo "repository variable once, or pass the input to override it per run."
+            echo "An input always overrides the variable."
+            echo ""
+            echo "| Parameter | Pass per run as | …or set once as repository variable |"
+            echo "|-----------|-----------------|--------------------------------------|"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "| \`${IN}\` | workflow input | \`gh variable set ${VAR}\` |"
+            done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
           [[ -z "$APP_NAME"    ]] && { echo "::error::app_name is required"; exit 1; }
           [[ -z "$ENVIRONMENT" ]] && { echo "::error::environment is required"; exit 1; }
@@ -157,6 +198,8 @@ jobs:
             echo "resource_group_name=$RG_NAME"
             echo "app_repo_full=$APP_REPO_FULL"
             echo "infra_repo_full=$INFRA_REPO_FULL"
+            echo "aws_region=$AWS_REGION"
+            echo "aws_role_arn=$AWS_ROLE_ARN"
           } >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────────────────────
@@ -182,8 +225,8 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ inputs.aws_role_arn || github.event.inputs.aws_role_arn }}
-          aws-region:     ${{ inputs.aws_region || github.event.inputs.aws_region }}
+          role-to-assume: ${{ needs.validate.outputs.aws_role_arn }}
+          aws-region:     ${{ needs.validate.outputs.aws_region }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
@@ -196,7 +239,7 @@ jobs:
         env:
           APP_NAME:    ${{ needs.validate.outputs.app_name }}
           ENVIRONMENT: ${{ needs.validate.outputs.environment }}
-          AWS_REGION:  ${{ inputs.aws_region || github.event.inputs.aws_region }}
+          AWS_REGION:  ${{ needs.validate.outputs.aws_region }}
           MAIN_DOMAIN: ${{ inputs.main_domain || github.event.inputs.main_domain }}
         run: |
           set -euo pipefail
@@ -259,7 +302,7 @@ jobs:
         env:
           APP_NAME:    ${{ needs.validate.outputs.app_name }}
           ENVIRONMENT: ${{ needs.validate.outputs.environment }}
-          AWS_REGION:  ${{ inputs.aws_region || github.event.inputs.aws_region }}
+          AWS_REGION:  ${{ needs.validate.outputs.aws_region }}
         run: |
           set -euo pipefail
 
@@ -314,8 +357,8 @@ jobs:
     uses: ./.github/workflows/delete-resource-group-aws.yml
     with:
       resource_group_name: ${{ needs.validate.outputs.resource_group_name }}
-      aws_region:          ${{ inputs.aws_region || github.event.inputs.aws_region }}
-      aws_role_arn:        ${{ inputs.aws_role_arn || github.event.inputs.aws_role_arn }}
+      aws_region:          ${{ needs.validate.outputs.aws_region }}
+      aws_role_arn:        ${{ needs.validate.outputs.aws_role_arn }}
 
   cleanup-github-and-oidc:
     name: Cleanup GitHub environment and OIDC
@@ -350,8 +393,8 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ inputs.aws_role_arn || github.event.inputs.aws_role_arn }}
-          aws-region:     ${{ inputs.aws_region || github.event.inputs.aws_region }}
+          role-to-assume: ${{ needs.validate.outputs.aws_role_arn }}
+          aws-region:     ${{ needs.validate.outputs.aws_region }}
 
       # Azure removes the environment's federated credential from the AD app.
       # The AWS analogue is the GitHub OIDC subject inside the IAM role's trust
@@ -369,7 +412,7 @@ jobs:
       # would win. Retire apps one at a time if they share a role.
       - name: Remove OIDC trust subject
         env:
-          ROLE_ARN:      ${{ inputs.aws_role_arn || github.event.inputs.aws_role_arn }}
+          ROLE_ARN:      ${{ needs.validate.outputs.aws_role_arn }}
           APP_REPO_FULL: ${{ needs.validate.outputs.app_repo_full }}
           TARGET_ENV:    ${{ needs.validate.outputs.environment }}
         run: |

--- a/.github/workflows/delete-app-resources-single.yml
+++ b/.github/workflows/delete-app-resources-single.yml
@@ -52,17 +52,17 @@ on:
         options: [dev, staging, prod]
         required: true
       azure_tenant_id:
-        description: Azure Tenant ID
+        description: "Azure Tenant ID (optional — falls back to the PROVISION_AZURE_TENANT_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_subscription_id:
-        description: Azure Subscription ID
+        description: "Azure Subscription ID (optional — falls back to the PROVISION_AZURE_SUBSCRIPTION_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_client_id:
-        description: Client ID of the Azure service principal / managed identity used for OIDC login
+        description: "Client ID of the Azure service principal / managed identity used for OIDC login (optional — falls back to the PROVISION_AZURE_CLIENT_ID repository variable)"
         type: string
-        required: true
+        required: false
       confirmation_app_name:
         description: Repeat the exact application name to confirm destructive deletion
         type: string
@@ -92,6 +92,9 @@ jobs:
       wait_for_completion: ${{ steps.out.outputs.wait_for_completion }}
       resource_group_name: ${{ steps.out.outputs.resource_group_name }}
       app_repo_full: ${{ steps.out.outputs.app_repo_full }}
+      azure_tenant_id: ${{ steps.out.outputs.azure_tenant_id }}
+      azure_subscription_id: ${{ steps.out.outputs.azure_subscription_id }}
+      azure_client_id: ${{ steps.out.outputs.azure_client_id }}
     steps:
       - name: Validate
         id: out
@@ -106,6 +109,15 @@ jobs:
           WD_CONFIRM_ENV: ${{ github.event.inputs.confirmation_environment }}
           IN_WAIT:        ${{ inputs.wait_for_completion }}
           WD_WAIT:        ${{ github.event.inputs.wait_for_completion }}
+          IN_TENANT_ID:   ${{ inputs.azure_tenant_id }}
+          WD_TENANT_ID:   ${{ github.event.inputs.azure_tenant_id }}
+          IN_SUB_ID:      ${{ inputs.azure_subscription_id }}
+          WD_SUB_ID:      ${{ github.event.inputs.azure_subscription_id }}
+          IN_CLIENT_ID:   ${{ inputs.azure_client_id }}
+          WD_CLIENT_ID:   ${{ github.event.inputs.azure_client_id }}
+          VAR_TENANT_ID:  ${{ vars.PROVISION_AZURE_TENANT_ID }}
+          VAR_SUB_ID:     ${{ vars.PROVISION_AZURE_SUBSCRIPTION_ID }}
+          VAR_CLIENT_ID:  ${{ vars.PROVISION_AZURE_CLIENT_ID }}
         run: |
           set -euo pipefail
 
@@ -114,6 +126,41 @@ jobs:
           CONFIRM_APP_NAME="${IN_CONFIRM_APP:-$WD_CONFIRM_APP}"
           CONFIRM_ENVIRONMENT="${IN_CONFIRM_ENV:-$WD_CONFIRM_ENV}"
           WAIT_FOR_COMPLETION="${IN_WAIT:-${WD_WAIT:-true}}"
+
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback. It
+          # only engages on the external interface (workflow_dispatch /
+          # repository_dispatch): workflow_call inputs stay required, so
+          # workflow-to-workflow calls always pass explicit values.
+          AZURE_TENANT_ID="${IN_TENANT_ID:-${WD_TENANT_ID:-$VAR_TENANT_ID}}"
+          AZURE_SUBSCRIPTION_ID="${IN_SUB_ID:-${WD_SUB_ID:-$VAR_SUB_ID}}"
+          AZURE_CLIENT_ID="${IN_CLIENT_ID:-${WD_CLIENT_ID:-$VAR_CLIENT_ID}}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AZURE_TENANT_ID" ]] && MISSING_CLOUD+=("azure_tenant_id|PROVISION_AZURE_TENANT_ID")
+          [[ -z "$AZURE_SUBSCRIPTION_ID" ]] && MISSING_CLOUD+=("azure_subscription_id|PROVISION_AZURE_SUBSCRIPTION_ID")
+          [[ -z "$AZURE_CLIENT_ID" ]] && MISSING_CLOUD+=("azure_client_id|PROVISION_AZURE_CLIENT_ID")
+          if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+            echo "## Missing target-cloud parameters"
+            echo ""
+            echo "The target cloud is usually locked in for the organization: set each"
+            echo "repository variable once, or pass the input to override it per run."
+            echo "An input always overrides the variable."
+            echo ""
+            echo "| Parameter | Pass per run as | …or set once as repository variable |"
+            echo "|-----------|-----------------|--------------------------------------|"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "| \`${IN}\` | workflow input | \`gh variable set ${VAR}\` |"
+            done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
           [[ -z "$APP_NAME" ]] && { echo "::error::app_name is required"; exit 1; }
           [[ -z "$ENVIRONMENT" ]] && { echo "::error::environment is required"; exit 1; }
@@ -147,6 +194,9 @@ jobs:
           echo "wait_for_completion=$WAIT_FOR_COMPLETION" >> "$GITHUB_OUTPUT"
           echo "resource_group_name=$RG_NAME" >> "$GITHUB_OUTPUT"
           echo "app_repo_full=$APP_REPO_FULL" >> "$GITHUB_OUTPUT"
+          echo "azure_tenant_id=$AZURE_TENANT_ID" >> "$GITHUB_OUTPUT"
+          echo "azure_subscription_id=$AZURE_SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
+          echo "azure_client_id=$AZURE_CLIENT_ID" >> "$GITHUB_OUTPUT"
 
   delete-rg:
     name: Delete Azure resource group
@@ -154,9 +204,9 @@ jobs:
     uses: ./.github/workflows/delete-resource-group.yml
     with:
       resource_group_name:   ${{ needs.validate.outputs.resource_group_name }}
-      azure_tenant_id:       ${{ inputs.azure_tenant_id || github.event.inputs.azure_tenant_id }}
-      azure_subscription_id: ${{ inputs.azure_subscription_id || github.event.inputs.azure_subscription_id }}
-      azure_client_id:       ${{ inputs.azure_client_id || github.event.inputs.azure_client_id }}
+      azure_tenant_id:       ${{ needs.validate.outputs.azure_tenant_id }}
+      azure_subscription_id: ${{ needs.validate.outputs.azure_subscription_id }}
+      azure_client_id:       ${{ needs.validate.outputs.azure_client_id }}
       wait_for_completion:   ${{ needs.validate.outputs.wait_for_completion }}
 
   cleanup-github-and-oidc:
@@ -191,9 +241,9 @@ jobs:
       - name: Azure login (OIDC)
         uses: azure/login@v3
         with:
-          tenant-id:       ${{ inputs.azure_tenant_id || github.event.inputs.azure_tenant_id }}
-          subscription-id: ${{ inputs.azure_subscription_id || github.event.inputs.azure_subscription_id }}
-          client-id:       ${{ inputs.azure_client_id || github.event.inputs.azure_client_id }}
+          tenant-id:       ${{ needs.validate.outputs.azure_tenant_id }}
+          subscription-id: ${{ needs.validate.outputs.azure_subscription_id }}
+          client-id:       ${{ needs.validate.outputs.azure_client_id }}
 
       # Deleting the resource group removes the resources but leaves this
       # environment's state blob fully populated, describing resources that no
@@ -212,7 +262,7 @@ jobs:
         env:
           APP_NAME:        ${{ needs.validate.outputs.app_name }}
           TARGET_ENV:      ${{ needs.validate.outputs.environment }}
-          SUBSCRIPTION_ID: ${{ inputs.azure_subscription_id || github.event.inputs.azure_subscription_id }}
+          SUBSCRIPTION_ID: ${{ needs.validate.outputs.azure_subscription_id }}
         run: |
           set -euo pipefail
 
@@ -258,7 +308,7 @@ jobs:
 
       - name: Remove OIDC federated credential
         env:
-          APP_ID:        ${{ inputs.azure_client_id || github.event.inputs.azure_client_id }}
+          APP_ID:        ${{ needs.validate.outputs.azure_client_id }}
           APP_REPO_FULL: ${{ needs.validate.outputs.app_repo_full }}
           TARGET_ENV:    ${{ needs.validate.outputs.environment }}
         run: |

--- a/.github/workflows/tag-app-resources-aws.yml
+++ b/.github/workflows/tag-app-resources-aws.yml
@@ -8,13 +8,13 @@ on:
         type: string
         required: true
       aws_region:
-        description: AWS region (e.g. us-east-1)
+        description: "AWS region (e.g. us-east-1) (optional — falls back to the PROVISION_AWS_REGION repository variable)"
         type: string
-        required: true
+        required: false
       aws_role_arn:
-        description: ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole)
+        description: "ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole) (optional — falls back to the PROVISION_AWS_ROLE_ARN repository variable)"
         type: string
-        required: true
+        required: false
       tags_json:
         description: 'JSON object of tags to apply to every resource, e.g. {"tag1":"value1","tag2":"value2","tag3":"value3"}'
         type: string
@@ -69,11 +69,54 @@ jobs:
           fi
           echo "Validated: app_name='$APP_NAME', tags=$TAG_COUNT"
 
+      - name: Resolve target-cloud parameters
+        id: cloud
+        env:
+          IN_AWS_REGION: ${{ inputs.aws_region }}
+          IN_AWS_ROLE_ARN: ${{ inputs.aws_role_arn }}
+          VAR_AWS_REGION: ${{ vars.PROVISION_AWS_REGION }}
+          VAR_AWS_ROLE_ARN: ${{ vars.PROVISION_AWS_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback
+          # (this workflow is dispatch-only, the external interface).
+          AWS_REGION="${IN_AWS_REGION:-$VAR_AWS_REGION}"
+          AWS_ROLE_ARN="${IN_AWS_ROLE_ARN:-$VAR_AWS_ROLE_ARN}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AWS_REGION" ]] && MISSING_CLOUD+=("aws_region|PROVISION_AWS_REGION")
+          [[ -z "$AWS_ROLE_ARN" ]] && MISSING_CLOUD+=("aws_role_arn|PROVISION_AWS_ROLE_ARN")
+          if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+            echo "## Missing target-cloud parameters"
+            echo ""
+            echo "The target cloud is usually locked in for the organization: set each"
+            echo "repository variable once, or pass the input to override it per run."
+            echo "An input always overrides the variable."
+            echo ""
+            echo "| Parameter | Pass per run as | …or set once as repository variable |"
+            echo "|-----------|-----------------|--------------------------------------|"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "| \`${IN}\` | workflow input | \`gh variable set ${VAR}\` |"
+            done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "aws_region=$AWS_REGION" >> "$GITHUB_OUTPUT"
+          echo "aws_role_arn=$AWS_ROLE_ARN" >> "$GITHUB_OUTPUT"
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ inputs.aws_role_arn }}
-          aws-region:     ${{ inputs.aws_region }}
+          role-to-assume: ${{ steps.cloud.outputs.aws_role_arn }}
+          aws-region:     ${{ steps.cloud.outputs.aws_region }}
 
       - name: Tag resources
         env:

--- a/.github/workflows/tag-app-resources.yml
+++ b/.github/workflows/tag-app-resources.yml
@@ -8,17 +8,17 @@ on:
         type: string
         required: true
       azure_tenant_id:
-        description: Azure Tenant ID
+        description: "Azure Tenant ID (optional — falls back to the PROVISION_AZURE_TENANT_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_subscription_id:
-        description: Azure Subscription ID
+        description: "Azure Subscription ID (optional — falls back to the PROVISION_AZURE_SUBSCRIPTION_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_client_id:
-        description: Client ID of the Azure service principal / managed identity used for OIDC login
+        description: "Client ID of the Azure service principal / managed identity used for OIDC login (optional — falls back to the PROVISION_AZURE_CLIENT_ID repository variable)"
         type: string
-        required: true
+        required: false
       tags_json:
         description: 'JSON object of tags to apply to every resource, e.g. {"tag1":"value1","tag2":"value2","tag3":"value3"}'
         type: string
@@ -73,19 +73,67 @@ jobs:
           fi
           echo "Validated: app_name='$APP_NAME', tags=$TAG_COUNT"
 
+      - name: Resolve target-cloud parameters
+        id: cloud
+        env:
+          IN_AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
+          IN_AZURE_SUBSCRIPTION_ID: ${{ inputs.azure_subscription_id }}
+          IN_AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
+          VAR_AZURE_TENANT_ID: ${{ vars.PROVISION_AZURE_TENANT_ID }}
+          VAR_AZURE_SUBSCRIPTION_ID: ${{ vars.PROVISION_AZURE_SUBSCRIPTION_ID }}
+          VAR_AZURE_CLIENT_ID: ${{ vars.PROVISION_AZURE_CLIENT_ID }}
+        run: |
+          set -euo pipefail
+
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback
+          # (this workflow is dispatch-only, the external interface).
+          AZURE_TENANT_ID="${IN_AZURE_TENANT_ID:-$VAR_AZURE_TENANT_ID}"
+          AZURE_SUBSCRIPTION_ID="${IN_AZURE_SUBSCRIPTION_ID:-$VAR_AZURE_SUBSCRIPTION_ID}"
+          AZURE_CLIENT_ID="${IN_AZURE_CLIENT_ID:-$VAR_AZURE_CLIENT_ID}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AZURE_TENANT_ID" ]] && MISSING_CLOUD+=("azure_tenant_id|PROVISION_AZURE_TENANT_ID")
+          [[ -z "$AZURE_SUBSCRIPTION_ID" ]] && MISSING_CLOUD+=("azure_subscription_id|PROVISION_AZURE_SUBSCRIPTION_ID")
+          [[ -z "$AZURE_CLIENT_ID" ]] && MISSING_CLOUD+=("azure_client_id|PROVISION_AZURE_CLIENT_ID")
+          if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+            echo "## Missing target-cloud parameters"
+            echo ""
+            echo "The target cloud is usually locked in for the organization: set each"
+            echo "repository variable once, or pass the input to override it per run."
+            echo "An input always overrides the variable."
+            echo ""
+            echo "| Parameter | Pass per run as | …or set once as repository variable |"
+            echo "|-----------|-----------------|--------------------------------------|"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "| \`${IN}\` | workflow input | \`gh variable set ${VAR}\` |"
+            done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "azure_tenant_id=$AZURE_TENANT_ID" >> "$GITHUB_OUTPUT"
+          echo "azure_subscription_id=$AZURE_SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
+          echo "azure_client_id=$AZURE_CLIENT_ID" >> "$GITHUB_OUTPUT"
       - name: Azure login (OIDC)
         uses: azure/login@v3
         with:
-          tenant-id:       ${{ inputs.azure_tenant_id }}
-          subscription-id: ${{ inputs.azure_subscription_id }}
-          client-id:       ${{ inputs.azure_client_id }}
+          tenant-id:       ${{ steps.cloud.outputs.azure_tenant_id }}
+          subscription-id: ${{ steps.cloud.outputs.azure_subscription_id }}
+          client-id:       ${{ steps.cloud.outputs.azure_client_id }}
 
       - name: Tag resources
         env:
           APP_NAME:              ${{ inputs.app_name }}
-          AZURE_TENANT_ID:       ${{ inputs.azure_tenant_id }}
-          AZURE_SUBSCRIPTION_ID: ${{ inputs.azure_subscription_id }}
-          AZURE_CLIENT_ID:       ${{ inputs.azure_client_id }}
+          AZURE_TENANT_ID:       ${{ steps.cloud.outputs.azure_tenant_id }}
+          AZURE_SUBSCRIPTION_ID: ${{ steps.cloud.outputs.azure_subscription_id }}
+          AZURE_CLIENT_ID:       ${{ steps.cloud.outputs.azure_client_id }}
           TAGS_JSON:             ${{ inputs.tags_json }}
           DRYRUN:                ${{ inputs.dry_run }}
         run: bash scripts/tag-app-resources-azure.sh

--- a/.github/workflows/verify-infrastructure-aws.yml
+++ b/.github/workflows/verify-infrastructure-aws.yml
@@ -65,13 +65,13 @@ on:
         required: true
         default: dev
       aws_region:
-        description: AWS region the stack was applied to (e.g. eu-west-1)
+        description: "AWS region the stack was applied to (e.g. eu-west-1) (optional — falls back to the PROVISION_AWS_REGION repository variable)"
         type: string
-        required: true
+        required: false
       aws_role_arn:
-        description: ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole)
+        description: "ARN of the IAM role to assume via OIDC (e.g. arn:aws:iam::123456789012:role/GitHubActionsRole) (optional — falls back to the PROVISION_AWS_ROLE_ARN repository variable)"
         type: string
-        required: true
+        required: false
       main_domain:
         description: "Root domain in Route 53 (leave empty to skip certificate, DNS and HTTPS checks)"
         type: string
@@ -120,12 +120,19 @@ jobs:
           RD_MAIN_DOMAIN:   ${{ github.event.client_payload.main_domain }}
           RD_INFRA_REPO:    ${{ github.event.client_payload.infra_repo }}
           RD_VERIFY_SCRIPT: ${{ github.event.client_payload.verify_script }}
+          VAR_REGION:       ${{ vars.PROVISION_AWS_REGION }}
+          VAR_ROLE_ARN:     ${{ vars.PROVISION_AWS_ROLE_ARN }}
           OWNER:            ${{ github.repository_owner }}
         run: |
           APP_NAME="${IN_APP:-$RD_APP}"
           ENVIRONMENT="${IN_ENV:-$RD_ENV}"
-          AWS_REGION="${IN_REGION:-$RD_REGION}"
-          AWS_ROLE_ARN="${IN_ROLE_ARN:-$RD_ROLE_ARN}"
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback. It
+          # only engages on the external interface (workflow_dispatch /
+          # repository_dispatch): workflow_call inputs stay required, so
+          # workflow-to-workflow calls always pass explicit values.
+          AWS_REGION="${IN_REGION:-${RD_REGION:-$VAR_REGION}}"
+          AWS_ROLE_ARN="${IN_ROLE_ARN:-${RD_ROLE_ARN:-$VAR_ROLE_ARN}}"
           MAIN_DOMAIN="${IN_MAIN_DOMAIN:-${RD_MAIN_DOMAIN:-}}"
           INFRA_REPO="${IN_INFRA_REPO:-$RD_INFRA_REPO}"
           # Canonical path of the verification script inside the infra repo.
@@ -134,10 +141,38 @@ jobs:
           MISSING=()
           [[ -z "$APP_NAME"     ]] && MISSING+=(app_name)
           [[ -z "$ENVIRONMENT"  ]] && MISSING+=(environment)
-          [[ -z "$AWS_REGION"   ]] && MISSING+=(aws_region)
-          [[ -z "$AWS_ROLE_ARN" ]] && MISSING+=(aws_role_arn)
-          if [[ ${#MISSING[@]} -gt 0 ]]; then
-            echo "::error::Missing required parameters: ${MISSING[*]}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AWS_REGION"   ]] && MISSING_CLOUD+=("aws_region|PROVISION_AWS_REGION")
+          [[ -z "$AWS_ROLE_ARN" ]] && MISSING_CLOUD+=("aws_role_arn|PROVISION_AWS_ROLE_ARN")
+          if [[ ${#MISSING[@]} -gt 0 || ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            [[ ${#MISSING[@]} -gt 0 ]] && echo "::error::Missing required parameters: ${MISSING[*]}"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+              if [[ ${#MISSING[@]} -gt 0 ]]; then
+                echo "## Missing required parameters"
+                echo ""
+                for M in "${MISSING[@]}"; do echo "- \`${M}\`"; done
+                echo ""
+              fi
+              if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+                echo "## Missing target-cloud parameters"
+                echo ""
+                echo "The target cloud is usually locked in for the organization: set each"
+                echo "repository variable once, or pass the input to override it per run."
+                echo "An input always overrides the variable."
+                echo ""
+                echo "| Parameter | Pass per run as | …or set once as repository variable |"
+                echo "|-----------|-----------------|--------------------------------------|"
+                for M in "${MISSING_CLOUD[@]}"; do
+                  IFS='|' read -r IN VAR <<<"$M"
+                  echo "| \`${IN}\` | workflow input / \`client_payload.${IN}\` | \`gh variable set ${VAR}\` |"
+                done
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 

--- a/.github/workflows/verify-infrastructure.yml
+++ b/.github/workflows/verify-infrastructure.yml
@@ -64,17 +64,17 @@ on:
         required: true
         default: dev
       azure_tenant_id:
-        description: Azure Tenant ID
+        description: "Azure Tenant ID (optional — falls back to the PROVISION_AZURE_TENANT_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_subscription_id:
-        description: Azure Subscription ID
+        description: "Azure Subscription ID (optional — falls back to the PROVISION_AZURE_SUBSCRIPTION_ID repository variable)"
         type: string
-        required: true
+        required: false
       azure_client_id:
-        description: Client ID of the Azure service principal used for OIDC login
+        description: "Client ID of the Azure service principal used for OIDC login (optional — falls back to the PROVISION_AZURE_CLIENT_ID repository variable)"
         type: string
-        required: true
+        required: false
       infra_repo:
         description: "Provisioned infrastructure repo holding scripts/verify.sh (owner/name). Leave empty to derive <owner>/<app_name>-infra."
         type: string
@@ -118,13 +118,21 @@ jobs:
           RD_CLIENT_ID:  ${{ github.event.client_payload.azure_client_id }}
           RD_INFRA_REPO: ${{ github.event.client_payload.infra_repo }}
           RD_VERIFY_SCRIPT: ${{ github.event.client_payload.verify_script }}
+          VAR_TENANT_ID: ${{ vars.PROVISION_AZURE_TENANT_ID }}
+          VAR_SUB_ID:    ${{ vars.PROVISION_AZURE_SUBSCRIPTION_ID }}
+          VAR_CLIENT_ID: ${{ vars.PROVISION_AZURE_CLIENT_ID }}
           OWNER:         ${{ github.repository_owner }}
         run: |
           APP_NAME="${IN_APP:-$RD_APP}"
           ENVIRONMENT="${IN_ENV:-$RD_ENV}"
-          AZURE_TENANT_ID="${IN_TENANT_ID:-$RD_TENANT_ID}"
-          AZURE_SUBSCRIPTION_ID="${IN_SUB_ID:-$RD_SUB_ID}"
-          AZURE_CLIENT_ID="${IN_CLIENT_ID:-$RD_CLIENT_ID}"
+          # Target-cloud parameters: an explicit input always wins; the
+          # PROVISION_* repository variable is the organization fallback. It
+          # only engages on the external interface (workflow_dispatch /
+          # repository_dispatch): workflow_call inputs stay required, so
+          # workflow-to-workflow calls always pass explicit values.
+          AZURE_TENANT_ID="${IN_TENANT_ID:-${RD_TENANT_ID:-$VAR_TENANT_ID}}"
+          AZURE_SUBSCRIPTION_ID="${IN_SUB_ID:-${RD_SUB_ID:-$VAR_SUB_ID}}"
+          AZURE_CLIENT_ID="${IN_CLIENT_ID:-${RD_CLIENT_ID:-$VAR_CLIENT_ID}}"
           INFRA_REPO="${IN_INFRA_REPO:-$RD_INFRA_REPO}"
           # Canonical path of the verification script inside the infra repo.
           VERIFY_SCRIPT="${IN_VERIFY_SCRIPT:-${RD_VERIFY_SCRIPT:-scripts/verify.sh}}"
@@ -132,11 +140,39 @@ jobs:
           MISSING=()
           [[ -z "$APP_NAME"              ]] && MISSING+=(app_name)
           [[ -z "$ENVIRONMENT"           ]] && MISSING+=(environment)
-          [[ -z "$AZURE_TENANT_ID"       ]] && MISSING+=(azure_tenant_id)
-          [[ -z "$AZURE_SUBSCRIPTION_ID" ]] && MISSING+=(azure_subscription_id)
-          [[ -z "$AZURE_CLIENT_ID"       ]] && MISSING+=(azure_client_id)
-          if [[ ${#MISSING[@]} -gt 0 ]]; then
-            echo "::error::Missing required parameters: ${MISSING[*]}"
+
+          MISSING_CLOUD=()
+          [[ -z "$AZURE_TENANT_ID"       ]] && MISSING_CLOUD+=("azure_tenant_id|PROVISION_AZURE_TENANT_ID")
+          [[ -z "$AZURE_SUBSCRIPTION_ID" ]] && MISSING_CLOUD+=("azure_subscription_id|PROVISION_AZURE_SUBSCRIPTION_ID")
+          [[ -z "$AZURE_CLIENT_ID"       ]] && MISSING_CLOUD+=("azure_client_id|PROVISION_AZURE_CLIENT_ID")
+          if [[ ${#MISSING[@]} -gt 0 || ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+            [[ ${#MISSING[@]} -gt 0 ]] && echo "::error::Missing required parameters: ${MISSING[*]}"
+            for M in "${MISSING_CLOUD[@]}"; do
+              IFS='|' read -r IN VAR <<<"$M"
+              echo "::error::Target-cloud parameter '${IN}' is missing — pass it as an input on this run, or set the repository variable ${VAR} once as the organization default."
+            done
+            {
+              if [[ ${#MISSING[@]} -gt 0 ]]; then
+                echo "## Missing required parameters"
+                echo ""
+                for M in "${MISSING[@]}"; do echo "- \`${M}\`"; done
+                echo ""
+              fi
+              if [[ ${#MISSING_CLOUD[@]} -gt 0 ]]; then
+                echo "## Missing target-cloud parameters"
+                echo ""
+                echo "The target cloud is usually locked in for the organization: set each"
+                echo "repository variable once, or pass the input to override it per run."
+                echo "An input always overrides the variable."
+                echo ""
+                echo "| Parameter | Pass per run as | …or set once as repository variable |"
+                echo "|-----------|-----------------|--------------------------------------|"
+                for M in "${MISSING_CLOUD[@]}"; do
+                  IFS='|' read -r IN VAR <<<"$M"
+                  echo "| \`${IN}\` | workflow input / \`client_payload.${IN}\` | \`gh variable set ${VAR}\` |"
+                done
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -409,7 +409,7 @@ and region parameters:
 | `app_name` | Yes | Application name — used to discover resource groups |
 | `tags_json` | Yes | JSON object whose keys/values become the tags, e.g. `{"airid":"309005","Application":"myapp","CreatedBy":"user"}` |
 | `dry_run` | No (default: `false`) | When `true`, discovers and lists all resources that would be tagged without writing anything |
-| *cloud credentials* | Yes | Azure: `azure_tenant_id`, `azure_subscription_id`, `azure_client_id`. AWS: `aws_region`, `aws_role_arn` |
+| *cloud credentials* | No* | Azure: `azure_tenant_id`, `azure_subscription_id`, `azure_client_id`. AWS: `aws_region`, `aws_role_arn`. Optional per run — each falls back to its `PROVISION_*` repository variable (the organization default); an input always overrides the variable, and with neither the run fails fast naming both |
 
 ### How to run
 

--- a/docs/setup-aws.md
+++ b/docs/setup-aws.md
@@ -321,6 +321,13 @@ gh variable set PROVISION_AWS_ROLE_ARN -R <org>/<platform-repo> --body "arn:aws:
 A per-run input always overrides the variable (the provisioning form hides
 these fields behind an "override the organization's defaults" checkbox).
 
+The same variables back **every workflow that touches cloud resources**: the
+provisioning/reconciling workflow, the delete workflows (single environment
+and all-environments), the verification workflow, and the tagging workflow
+all fall back to them when dispatched without explicit cloud parameters.
+Workflow-to-workflow calls are unaffected — reusable-workflow inputs stay
+required, and callers always pass explicit values.
+
 ### What you should observe
 
 Each row below names the job exactly as it appears in the run's UI. Jobs

--- a/docs/setup-azure.md
+++ b/docs/setup-azure.md
@@ -429,6 +429,13 @@ gh variable set PROVISION_AZURE_LOCATION        -R <org>/<platform-repo> --body 
 A per-run input always overrides the variable (the provisioning form hides
 these fields behind an "override the organization's defaults" checkbox).
 
+The same variables back **every workflow that touches cloud resources**: the
+provisioning/reconciling workflow, the delete workflows (single environment
+and all-environments), the verification workflow, and the tagging workflow
+all fall back to them when dispatched without explicit cloud parameters.
+Workflow-to-workflow calls are unaffected — reusable-workflow inputs stay
+required, and callers always pass explicit values.
+
 ### What you should observe
 
 Each row below names the job exactly as it appears in the run's UI. Jobs


### PR DESCRIPTION
… workflows

Applies the P19 contract to the eight workflows that delete, verify or tag resources, on both clouds. The target-cloud parameters (azure_tenant_id / azure_subscription_id / azure_client_id; aws_region / aws_role_arn) become optional workflow_dispatch inputs with no default, falling back to the same shared PROVISION_* repository variables; an explicit input always wins, and with neither the run fails fast with the P19 report shape (per-parameter ::error:: naming both sources plus the job-summary table with the exact gh variable set commands).

Per the task definition, the fallback lives ONLY at the external interface (workflow_dispatch, and repository_dispatch on the verify workflows): workflow_call inputs stay required, so workflow-to-workflow calls always pass explicit values — the provisioning orchestrator calling verify and delete-all calling delete-single are unchanged, verified against the callers' with-blocks.

Resolution is centralised per workflow (the existing validate/params step, or a new resolve step in the single-job tag workflows) and every consumer reads the resolved outputs. The delete workflows' safety gates (confirmation phrases, app-name matching) are untouched.

Docs: the setup guides' "Lock in the target cloud" sections now state the variables back the whole workflow family, and the tagging inputs table in index.md marks the cloud credentials optional-with-fallback.

Closes #61 (P20).